### PR TITLE
Switched from using -jar execution to -cp

### DIFF
--- a/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
+++ b/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
@@ -19,7 +19,7 @@ exec >> ${LOG_FILE} 2>&1
 echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 echo `date` Starting psc-pursuit-trigger
 
-/usr/java/jdk-8/bin/java -Din=psc-pursuit-trigger -Dlog4j.configuration=log4j.xml -jar psc-pursuit-trigger.jar psc-pursuit-trigger.properties
+/usr/java/jdk-8/bin/java -Din=psc-pursuit-trigger -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.psc.pursuit.trigger.PscPursuitTrigger psc-pursuit-trigger.properties
 if [ $? -gt 0 ]; then
         echo "Non-zero exit code for psc-pursuit-trigger java execution"
         exit 1


### PR DESCRIPTION
When using -jar option the JAR file is source of all user classes but
other user class path settings are ignored.

As no class path entries are defined in this jar manifest so must
specify all on command line via this syntax to avoid
java.lang.NoClassDefFoundError errors.