### PR TITLE
CM-1102 chips weblogic batch configuration for bulkimageload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ENV ORACLE_HOME=/apps/oracle \
 
 RUN yum -y install gettext && \
     yum -y install cronie && \
+    yum -y install oracle-instantclient-release-el7 && \
+    yum -y install oracle-instantclient-basic && \
+    yum -y install oracle-instantclient-sqlplus && \
+    yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y install msmtp && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -24,9 +29,11 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/org/springframework/spring/2.0.7/spring-2.0.7.jar -o spring.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar -o commons-logging.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/ojdbc8/12.2.1.4/ojdbc8-12.2.1.4.jar -o ojdbc8.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlthint3client/12.2.1.4/wlthint3client-12.2.1.4.jar -o wlthint3client.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.1/jmstool-0.0.1.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.0/psc-pursuit-trigger-1.9.0.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     chmod -R 750 ${ORACLE_HOME}/*
 
 WORKDIR $ORACLE_HOME

--- a/weblogic-batch/.msmtprc.template
+++ b/weblogic-batch/.msmtprc.template
@@ -1,0 +1,3 @@
+account default
+host ${MAIL_HOST}
+from ${MAIL_DEFAULT_FROM}

--- a/weblogic-batch/batchmanager/batchmanager.sh
+++ b/weblogic-batch/batchmanager/batchmanager.sh
@@ -7,7 +7,7 @@ source /apps/oracle/env.variables
 # create properties file and substitutes values
 envsubst < batchmanager.properties.template > chips_batchmanager.properties
 
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/libs/spring.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/batchmanager/batch-manager.jar
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/spring.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/batchmanager/batch-manager.jar
 # set up logging
 LOGS_DIR=../logs/batchmanager
 mkdir -p ${LOGS_DIR}

--- a/weblogic-batch/bulk-image-load/bulk-image-load.properties.template
+++ b/weblogic-batch/bulk-image-load/bulk-image-load.properties.template
@@ -1,0 +1,3 @@
+java.naming.provider.url=${JMS_JNDIPROVIDERURL}
+java.naming.security.principal=${WEBLOGIC_ADMIN_USERNAME}
+java.naming.security.credentials=${ADMIN_PASSWORD}

--- a/weblogic-batch/bulk-image-load/bulk-image-load.sh
+++ b/weblogic-batch/bulk-image-load/bulk-image-load.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cd /apps/oracle/bulk-image-load
+
+# load variables created from setCron script
+source /apps/oracle/env.variables
+# create properties file and substitutes values
+envsubst < bulk-image-load.properties.template > bulk-image-load.properties
+
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/bulk-image-load/bulk-image-load.jar
+
+# Set up mail config for msmtp & load alerting functions
+envsubst < ../.msmtprc.template > ../.msmtprc
+source ../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../logs/bulk-image-load
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-bulk-image-load-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >> ${LOG_FILE} 2>&1
+
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+echo `date` Starting bulk-image-load
+
+echo Checking that bulk-image-load is not already running
+../scripts/check-for-jms-message.sh ${JMS_BULKIMAGELOADQUEUE}
+if [ $? -gt 0 ]; then
+        echo `date`": bulk-image-load may be already running or connection error.  Please investigate."
+        patrol_log_alert_chaps_f " `pwd`/`basename $0`:  bulk-image-load may be already running or connection error.  Please investigate."
+        exit 1
+fi
+
+echo Count how many rows are in IMAGE_API_IN before job runs
+./count_image_api_in_table.command
+
+echo Delete any duplicate rows in IMAGE_API_IN before job runs
+./remove_duplicates_from_image_api_in_table.command
+
+/usr/java/jdk-8/bin/java -Din=bulk-image-load -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.bulkimageload.BulkImageLoadRunner bulk-image-load.properties
+if [ $? -gt 0 ]; then
+        echo "Non-zero exit code for bulk-image-load java execution"
+        exit 1
+fi
+
+echo `date` Ending bulk-image-load
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
+++ b/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
@@ -8,7 +8,7 @@ cd /apps/oracle/bulk-image-load
 # load variables created from setCron script
 source /apps/oracle/env.variables
 
-CLOUD_IMAGES_DIR=chipsdomain/CloudImages
+CLOUD_IMAGES_DIR=../chipsdomain/CloudImages
 STUCK_FILE_LIST=/tmp/monitor_cloud_images_msg
 
 # set up logging

--- a/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
+++ b/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Description   : Monitors CloudImages directory for stale docs
+#                 known issue file in dir is corrupt we need to delete the file and resend to CHS
+
+cd /apps/oracle/bulk-image-load
+
+# load variables created from setCron script
+source /apps/oracle/env.variables
+
+CLOUD_IMAGES_DIR=chipsdomain/CloudImages
+STUCK_FILE_LIST=/tmp/monitor_cloud_images_msg
+
+# set up logging
+LOGS_DIR=../logs/bulk-image-load
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-clear-cloud-images-dir-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >> ${LOG_FILE} 2>&1
+
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+echo `date` Starting clear-cloud-images-dir
+
+find $CLOUD_IMAGES_DIR/ -type f -mtime +0.5 > $STUCK_FILE_LIST
+
+echo "\n\nThe following docs are stuck in CloudImages on $HOSTNAME `date +%d/%m/%y`  please investigate" >> $LOG_FILE
+
+if [ -s $STUCK_FILE_LIST ]
+then
+  for line in `cat $STUCK_FILE_LIST`
+  do
+     echo removing file $line >> $LOG_FILE
+     rm $line
+  done
+fi
+
+echo `date` Ending clear-cloud-images-dir
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/bulk-image-load/count_image_api_in_table.command
+++ b/weblogic-batch/bulk-image-load/count_image_api_in_table.command
@@ -5,13 +5,9 @@ OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
        select count(*) from chipstab.image_api_in;
 EOF`
 
-#echo count_image_api_in_table.command OUTPUT = $OUTPUT
 OUTPUT=`echo "${OUTPUT}" | head -2`
 RESULT=`echo ${OUTPUT} | sed 's/ //g'`
 
 echo Result of count_image_api_in_table is $RESULT
-
-## if we have a 1 returned, then we could have an error - exit 1 for parent script
-#(( ${RESULT} > 10 )) && exit 1
 
 exit 0

--- a/weblogic-batch/bulk-image-load/count_image_api_in_table.command
+++ b/weblogic-batch/bulk-image-load/count_image_api_in_table.command
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+       set head off;
+       select count(*) from chipstab.image_api_in;
+EOF`
+
+#echo count_image_api_in_table.command OUTPUT = $OUTPUT
+OUTPUT=`echo "${OUTPUT}" | head -2`
+RESULT=`echo ${OUTPUT} | sed 's/ //g'`
+
+echo Result of count_image_api_in_table is $RESULT
+
+## if we have a 1 returned, then we could have an error - exit 1 for parent script
+#(( ${RESULT} > 10 )) && exit 1
+
+exit 0

--- a/weblogic-batch/bulk-image-load/remove_duplicates_from_image_api_in_table.command
+++ b/weblogic-batch/bulk-image-load/remove_duplicates_from_image_api_in_table.command
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+--Temporary table with indexes
+create table tmp_dedup_image_api_in as
+select * from image_api_in;
+
+create index tmp_dedup_image_api_in_tran ON tmp_dedup_image_api_in (transaction_id);
+create index tmp_dedup_image_api_in_image ON tmp_dedup_image_api_in (image_file_reference);
+
+DECLARE
+v_duplicate_count    NUMBER(10);
+
+BEGIN
+
+FOR image_api_in_request IN (select unique iai.image_file_reference from tmp_dedup_image_api_in iai where (select count(*) from tmp_dedup_image_api_in iaii where iaii.image_file_reference=iai.image_file_reference
+and iaii.transaction_id=iai.transaction_id) > 1
+)
+LOOP
+
+    select count(*) into v_duplicate_count from tmp_dedup_image_api_in iai where iai.image_file_reference=image_api_in_request.image_file_reference;
+
+    dbms_output.put_line(TO_CHAR(SYSDATE,'hh24:mi:ss > ')||v_duplicate_count||' requests found for image_reference '|| image_api_in_request.image_file_reference);
+
+    delete from image_api_in where image_file_reference=image_api_in_request.image_file_reference and
+    rowid > any(select iai.rowid from image_api_in iai where iai.image_file_reference=image_api_in_request.image_file_reference);
+
+    dbms_output.put_line(TO_CHAR(SYSDATE,'hh24:mi:ss > ')||SQL%ROWCOUNT||' request(s) deleted for image_reference '|| image_api_in_request.image_file_reference);
+
+END LOOP;
+
+END;
+
+EOF`
+
+echo ${OUTPUT}
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+drop table tmp_dedup_image_api_in;
+
+EOF`
+
+echo ${OUTPUT}
+
+exit 0

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -6,3 +6,9 @@
 
 # psc-pursuit-trigger
 #30 03 * * 2-6 $HOME/psc-pursuit-trigger/psc-pursuit-trigger.sh
+
+## Overnight job to clear any images stuck in CloudImages
+#15 03 * * * $HOME/bulkimageload/clear-cloud-images-dir.sh
+## Daily bulkimageload job to run after dps_in
+#30 05 * * * $HOME/bulkimageload/bulk-image-load.sh
+#45 14 * * * $HOME/bulkimageload/bulk-image-load.sh

--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -5,6 +5,16 @@
 #
 #######################################################
 
+## returns 1 if variable EMAIL_ADDRESS_CSI is unset or a blank string, otherwise 0 
+
+check_email_address_defined_f ()
+{
+  if [ -z "${EMAIL_ADDRESS_CSI}" ]; then
+    echo `date`": Unable to send email alert - no address set in EMAIL_ADDRESS_CSI."
+    return 1
+  fi
+}
+
 
 ## The function patrol_log_alert_chaps_f is used to write a particular string to a remote
 ## log file so that BMC Patrol can immediately alert the Oncall officer.
@@ -24,8 +34,10 @@
 patrol_log_alert_chaps_f ()
 {
   if [[ ${LIVE_ENVIRONMENT} == "true" ]]; then
-    echo `date`: alert_chaps \> $1  >> /apps/oracle/chaplive/log/chapspatrol.log
-    echo -e "To:CSI@companieshouse.gov.uk\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$1" | msmtp -t
+    echo `date`: alert_chaps \> $1  >> /apps/oracle/alertlog/chapspatrol.log
+    if check_email_address_defined_f; then
+      echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$1" | msmtp -t
+    fi
   fi
 }
 
@@ -37,7 +49,7 @@ patrol_log_testharness_f ()
 {
   echo `date`": Lets write a test string via patrol_log_test_f to chapspatrol.log."
   ## Write a test string that will NOT kick off Patrol alarm.
-  echo `date`: TEST \> $1  >> /apps/oracle/chaplive/log/chapspatrol.log
+  echo `date`: TEST \> $1  >> /apps/oracle/alertlog/chapspatrol.log
 }
 
 ##
@@ -52,16 +64,16 @@ patrol_log_testharness_f ()
 
 email_CHAPS_group_f ()
 {
-  alertemails=csi@companieshouse.gov.uk
-  echo -e "To:$alertemails\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
-  echo -e "To:companieshouse@service-now.com\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
-
+  if check_email_address_defined_f; then
+    echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_SERVICENOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
+  fi
 }
 
 
 email_report_CHAPS_group_f ()
 {
-  alertemails=csi@companieshouse.gov.uk
-  echo -e "To:$alertemails\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Report: $1 \n$2" | msmtp -t
-
+  if check_email_address_defined_f; then
+     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Report: $1 \n$2" | msmtp -t
+  fi
 }

--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -1,0 +1,67 @@
+#######################################################
+#
+# This file contains only functions for BMC Patrol
+# and email alerts
+#
+#######################################################
+
+
+## The function patrol_log_alert_chaps_f is used to write a particular string to a remote
+## log file so that BMC Patrol can immediately alert the Oncall officer.
+##
+## If used, the CHAPLOG variable is set by UNIX_OPS in all servers .profile and loaded by at user level login.
+##
+## The function accepts an enclosed string that MUST contain:
+## patrol_log_alert_chaps_f " [path] [script_name] [helpful_text] "
+##
+## The path is used to distinguish test and live systems so one script can be used throughout
+## helpful_text must show the on-call officer what failed and where to look
+##
+## Example:
+##   patrol_log_alert_chaps_f " `pwd`/`basename $0`: LetterProducer may be already running or connection error."
+##
+
+patrol_log_alert_chaps_f ()
+{
+  if [[ ${LIVE_ENVIRONMENT} == "true" ]]; then
+    echo `date`: alert_chaps \> $1  >> /apps/oracle/chaplive/log/chapspatrol.log
+    echo -e "To:CSI@companieshouse.gov.uk\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$1" | msmtp -t
+  fi
+}
+
+##
+## This test script writes a non-alert string to log file for testing access permissions
+##
+
+patrol_log_testharness_f ()
+{
+  echo `date`": Lets write a test string via patrol_log_test_f to chapspatrol.log."
+  ## Write a test string that will NOT kick off Patrol alarm.
+  echo `date`: TEST \> $1  >> /apps/oracle/chaplive/log/chapspatrol.log
+}
+
+##
+## This function will send string via email to CHAPS group.
+## This function accepts accepts two arguments.
+##
+## First is subject as an enclosed string .
+## Second is body text as an enclosed string .
+##
+## Example:
+##  email_CHAPS_group_f "Disk Space high on chpwlo-pl3" "Please check disk space on Weblogic Servers"
+
+email_CHAPS_group_f ()
+{
+  alertemails=csi@companieshouse.gov.uk
+  echo -e "To:$alertemails\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
+  echo -e "To:companieshouse@service-now.com\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
+
+}
+
+
+email_report_CHAPS_group_f ()
+{
+  alertemails=csi@companieshouse.gov.uk
+  echo -e "To:$alertemails\nFrom:CSI@companieshouse.gov.uk\nSubject:CHAPS Report: $1 \n$2" | msmtp -t
+
+}

--- a/weblogic-batch/scripts/check-for-jms-message.sh
+++ b/weblogic-batch/scripts/check-for-jms-message.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cd /apps/oracle/scripts
+
+# load variables created from setCron script if needed
+source /apps/oracle/env.variables
+
+if [ -z "$1" ]; then
+    echo `date`": Unable to confirm if process is already running on - no queue name passed as a parameter."
+    exit 1
+fi
+QUEUE_NAME=$1
+
+JNDI_QUEUE_NAME=${JMS_SERVER_NAME}@${QUEUE_NAME}
+URL=${JMS_JNDIPROVIDERURL}
+USERNAME=${WEBLOGIC_ADMIN_USERNAME}
+PASSWORD=${ADMIN_PASSWORD}
+RESULT=1
+
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs//wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/libs/jmstool.jar
+
+## Check 1p server
+UNPROCESSEDCOUNT=`/usr/java/jdk-8/bin/java -cp $CLASSPATH chaps.jms.JMSQueueStats $JNDI_QUEUE_NAME $URL $USERNAME $PASSWORD | grep UNPROCESSED | awk -F: '{print $2}'`
+
+if [ -z "$UNPROCESSEDCOUNT" ]; then
+  echo `date`": Unable to confirm if process is already running on - possible issue with connection to Weblogic or other problem."
+  exit 1
+fi
+
+if [ "$UNPROCESSEDCOUNT" -eq 0 ]; then
+  echo `date`": OK. No unprocessed messages detected in ${QUEUE_NAME}."
+  exit 0
+fi
+
+## if we find a message on 1p, process already running so exit one.
+if [ "$UNPROCESSEDCOUNT" -gt 0 ]; then
+  echo `date`": Message detected in ${QUEUE_NAME}.  Process still processing  ..."
+  exit 1
+fi
+
+exit $RESULT

--- a/weblogic-batch/scripts/check-for-jms-message.sh
+++ b/weblogic-batch/scripts/check-for-jms-message.sh
@@ -10,17 +10,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 QUEUE_NAME=$1
-
-JNDI_QUEUE_NAME=${JMS_SERVER_NAME}@${QUEUE_NAME}
-URL=${JMS_JNDIPROVIDERURL}
-USERNAME=${WEBLOGIC_ADMIN_USERNAME}
-PASSWORD=${ADMIN_PASSWORD}
 RESULT=1
 
 CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs//wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/libs/jmstool.jar
 
 ## Check 1p server
-UNPROCESSEDCOUNT=`/usr/java/jdk-8/bin/java -cp $CLASSPATH chaps.jms.JMSQueueStats $JNDI_QUEUE_NAME $URL $USERNAME $PASSWORD | grep UNPROCESSED | awk -F: '{print $2}'`
+UNPROCESSEDCOUNT=`/usr/java/jdk-8/bin/java -cp $CLASSPATH chaps.jms.JMSQueueStats ${JMS_SERVER_NAME}@${QUEUE_NAME} ${JMS_JNDIPROVIDERURL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD} | grep UNPROCESSED | awk -F: '{print $2}'`
 
 if [ -z "$UNPROCESSEDCOUNT" ]; then
   echo `date`": Unable to confirm if process is already running on - possible issue with connection to Weblogic or other problem."

--- a/weblogic-batch/setCron.sh
+++ b/weblogic-batch/setCron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# sed command to add export to beginning of each line
-env | sed 's/^/export /' > /apps/oracle/env.variables
+# sed command to add export to beginning of each line and quote values
+env | sed 's/^/export /;s/=/&"/;s/$/"/' > /apps/oracle/env.variables
 
 # set weblogic user crontab
 su -c 'crontab /apps/oracle/cron/crontab.txt' weblogic


### PR DESCRIPTION
First pass at adding bulk image load based on scripts running in prod

Overnight cleanup script clear-cloud-images-dir.sh based on current clearAppsBeaCloudImagesDir.sh
    (with email sending & DB reinsertion removed as Jake advised no longer required)

Main job (DB checks + JMS trigger) bulk-image-load.sh based on current bulkimageload.sh

For DB connections, added yum install of packages required for sqlplus
For email sending, added yum install of packages required for msmtp & a .msmptrc config file
Created a scripts dir for shared use containing alert_functions & check-for-jms-message.sh

These changes require the following additional environment setup:

chips.properties:
CHIPS_SQLPLUS_CONN_STRING="usr/pwd@host:port/servicename"
JMS_SERVER_NAME="JMSServer1"
WEBLOGIC_ADMIN_USERNAME="weblogic"
MAIL_HOST="mailhost.internal.ch"
MAIL_DEFAULT_FROM="chips-weblogic-batch@companieshouse.gov.uk"
LIVE_ENVIRONMENT="false"

docker-compose.yml:
batch service requires access to volumes for chaplive/log & cloudimages