### PR TITLE
CM-1102 minor fixes after testing in staging environment

### DIFF
--- a/weblogic-batch/bulk-image-load/bulk-image-load.sh
+++ b/weblogic-batch/bulk-image-load/bulk-image-load.sh
@@ -2,8 +2,11 @@
 
 cd /apps/oracle/bulk-image-load
 
-# load variables created from setCron script
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
 source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
 # create properties file and substitutes values
 envsubst < bulk-image-load.properties.template > bulk-image-load.properties
 

--- a/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
+++ b/weblogic-batch/bulk-image-load/clear-cloud-images-dir.sh
@@ -23,7 +23,7 @@ echo `date` Starting clear-cloud-images-dir
 
 find $CLOUD_IMAGES_DIR/ -type f -mtime +0.5 > $STUCK_FILE_LIST
 
-echo "\n\nThe following docs are stuck in CloudImages on $HOSTNAME `date +%d/%m/%y`  please investigate" >> $LOG_FILE
+echo "Deleting the following docs that are stuck in CloudImages on $HOSTNAME `date +%d/%m/%y`" >> $LOG_FILE
 
 if [ -s $STUCK_FILE_LIST ]
 then

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -8,7 +8,7 @@
 #30 03 * * 2-6 $HOME/psc-pursuit-trigger/psc-pursuit-trigger.sh
 
 ## Overnight job to clear any images stuck in CloudImages
-#15 03 * * * $HOME/bulkimageload/clear-cloud-images-dir.sh
-## Daily bulkimageload job to run after dps_in
-#30 05 * * * $HOME/bulkimageload/bulk-image-load.sh
-#45 14 * * * $HOME/bulkimageload/bulk-image-load.sh
+#15 03 * * * $HOME/bulk-image-load/clear-cloud-images-dir.sh
+## Daily bulk-image-load job to run after dps_in
+#30 05 * * * $HOME/bulk-image-load/bulk-image-load.sh
+#45 14 * * * $HOME/bulk-image-load/bulk-image-load.sh

--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -36,7 +36,7 @@ patrol_log_alert_chaps_f ()
   if [[ ${LIVE_ENVIRONMENT} == "true" ]]; then
     echo `date`: alert_chaps \> $1  >> /apps/oracle/alertlog/chapspatrol.log
     if check_email_address_defined_f; then
-      echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$1" | msmtp -t
+      echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$1" | msmtp -t
     fi
   fi
 }
@@ -65,8 +65,8 @@ patrol_log_testharness_f ()
 email_CHAPS_group_f ()
 {
   if check_email_address_defined_f; then
-    echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
-    echo -e "To:${EMAIL_ADDRESS_SERVICENOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1 \n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_SERVICENOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
   fi
 }
 
@@ -74,6 +74,6 @@ email_CHAPS_group_f ()
 email_report_CHAPS_group_f ()
 {
   if check_email_address_defined_f; then
-     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Report: $1 \n$2" | msmtp -t
+     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Report: $1\n\n$2" | msmtp -t
   fi
 }


### PR DESCRIPTION
Corrected directory name in crontab entries
Captured & reinstated correct HOME value in bulk-image-load.sh so that mail config is found properly
Added 2nd newline between message subjects & bodies in email calls for more reliable separation
Cleaned up log message in clear-cloud-images-dir.sh script