### PR TITLE
CM-1098: Update to use log4j2 version of psc-pursuit-trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.1/jmstool-0.0.1.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.0/psc-pursuit-trigger-1.9.0.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.1/psc-pursuit-trigger-1.9.1.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     chmod -R 750 ${ORACLE_HOME}/*
 

--- a/weblogic-batch/psc-pursuit-trigger/log4j2.xml
+++ b/weblogic-batch/psc-pursuit-trigger/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} [%t]  %-5level - %m%n" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.apache.log4j.xml" level="info" />
+        <Root level="debug">
+            <AppenderRef ref="ConsoleAppender" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
+++ b/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
@@ -7,7 +7,10 @@ source /apps/oracle/env.variables
 # create properties file and substitutes values
 envsubst < psc-pursuit-trigger.properties.template > psc-pursuit-trigger.properties
 
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/ojdbc8.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/psc-pursuit-trigger/psc-pursuit-trigger.jar
+
+LIBS_DIR=/apps/oracle/libs
+CLASSPATH=${CLASSPATH}:.:${LIBS_DIR}/log4j-api.jar:${LIBS_DIR}/log4j-core.jar:${LIBS_DIR}/ojdbc8.jar:/apps/oracle/psc-pursuit-trigger/psc-pursuit-trigger.jar
+
 
 # set up logging
 LOGS_DIR=../logs/psc-pursuit-trigger
@@ -17,13 +20,14 @@ LOG_FILE="${LOGS_DIR}/${HOSTNAME}-psc-pursuit-trigger-$(date +'%Y-%m-%d_%H-%M-%S
 exec >> ${LOG_FILE} 2>&1
 
 echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-echo `date` Starting psc-pursuit-trigger
+echo `date --iso-8601=seconds` Starting psc-pursuit-trigger
 
-/usr/java/jdk-8/bin/java -Din=psc-pursuit-trigger -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.psc.pursuit.trigger.PscPursuitTrigger psc-pursuit-trigger.properties
+/usr/java/jdk-8/bin/java -Din=psc-pursuit-trigger -cp ${CLASSPATH} -Dlog4j.configurationFile=log4j2.xml uk.gov.companieshouse.psc.pursuit.trigger.PscPursuitTrigger psc-pursuit-trigger.properties
+
 if [ $? -gt 0 ]; then
         echo "Non-zero exit code for psc-pursuit-trigger java execution"
         exit 1
 fi
 
-echo `date` Ending psc-pursuit-trigger
+echo `date --iso-8601=seconds` Ending psc-pursuit-trigger
 echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Dockerfile update brings in log4j2 psc-pursuit-trigger version.

Sole console appender in log4j2.xml to log to file per the invocation
based convention defined in psc-pursuit-trigger.sh.

Adopts use of -Dlog4j.configurationFile  over -Dlog4j.configuration for
log4j2 file designation.

Tweak to use 'date --iso-8601=seconds' to help standardize date logging
across shell and application.

e.g.
2022-03-01T16:44:55+0000 Starting psc-pursuit-trigger
2022-03-01T16:44:55,989 [main]  INFO  - ----------
2022-03-01T16:44:55,999 [main]  INFO  - Psc Pursuit trigger invoked ...

