### PR TITLE
CM-1101 initial checkin for adding officer scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,21 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar -o log4j-api.jar && \    
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar -o log4j-core.jar && \        
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/org/apache/logging/log4j/log4j-1.2-api/2.17.1/log4j-1.2-api-2.17.1.jar -o log4j-1.2-api.jar && \        
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/org/springframework/spring/2.0.7/spring-2.0.7.jar -o spring.jar && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar -o commons-logging.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/ojdbc8/12.2.1.4/ojdbc8-12.2.1.4.jar -o ojdbc8.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/thoughtworks/xstream/xstream/1.4.3/xstream-1.4.3.jar -o xstream.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/commons-lang/commons-lang/2.5/commons-lang-2.5.jar -o commons-lang.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/cglib/cglib-nodep/2.1_3/cglib-nodep-2.1_3.jar -o cglib-nodep.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/joda-time/joda-time/2.9.1/joda-time-2.9.1.jar -o joda-time.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/ojdbc8/12.2.1.4/ojdbc8-12.2.1.4.jar -o ojdbc8.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.1/jmstool-0.0.1.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.1/psc-pursuit-trigger-1.9.1.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/image-regeneration/1.2.5/image-regeneration-1.2.5.jar -o ../image-regeneration/image-regeneration.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/image-regeneration/1.2.5/image-regeneration-1.2.5.jar -o ../image-regeneration/image-regeneration.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/officer-bulk-process/1.0.3/officer-bulk-process-1.0.3.jar -o ../officer-bulk-process/officer-bulk-process.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.1/psc-pursuit-trigger-1.9.1.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
     chmod -R 750 ${ORACLE_HOME}/*
 
 WORKDIR $ORACLE_HOME

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -12,3 +12,11 @@
 ## Daily bulk-image-load job to run after dps_in
 30 05 * * * $HOME/bulk-image-load/bulk-image-load.sh
 45 14 * * * $HOME/bulk-image-load/bulk-image-load.sh
+
+# officer-bulk-process
+# 00 04 * * 0-6 $HOME/officer-bulk-process/officer-bulk-process./sh
+
+## Officer Lock file reminder
+# 30 15 * * * $HOME/officer-bulk-process/check-lock-file-reminder.sh
+## Check Zombie Officer in chipstab.officer_detail_match
+# 30 15 * * * $HOME/officer-bulk-process/check--10000-exists.sh 2>&1 >/dev/null

--- a/weblogic-batch/officer-bulk-process/bulk-officer.xml
+++ b/weblogic-batch/officer-bulk-process/bulk-officer.xml
@@ -1,0 +1,40 @@
+<officer-bulk-configuration>
+    <mergeThreshold>100</mergeThreshold>
+    <workItemSize>19</workItemSize>
+    <workItemGroupThreshold>15</workItemGroupThreshold>
+    <firstTimeLetterSuppressed>true</firstTimeLetterSuppressed>
+    <deduplicationSuppressed>false</deduplicationSuppressed>
+    <username>weblogic</username>
+
+    <bulkCriterias>
+        <bulkCriteria>
+            <exactCriteriaName>uk.gov.ch.chips.server.director.search.bulk.FullDuplicateCriteria</exactCriteriaName>
+            <exactEnabled>true</exactEnabled>
+            <aliasCriteriaName>uk.gov.ch.chips.server.director.search.bulk.FullDuplicateAliasCriteria</aliasCriteriaName>
+            <aliasEnabled>false</aliasEnabled>
+        </bulkCriteria>
+        <bulkCriteria>
+            <exactCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingStreetDuplicateCriteria</exactCriteriaName>
+            <exactEnabled>true</exactEnabled>
+            <aliasCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingStreetDuplicateAliasCriteria</aliasCriteriaName>
+            <aliasEnabled>false</aliasEnabled>
+        </bulkCriteria>
+        <bulkCriteria>
+            <exactCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingPostcodeDuplicateCriteria</exactCriteriaName>
+            <exactEnabled>true</exactEnabled>
+            <aliasCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingPostcodeDuplicateAliasCriteria</aliasCriteriaName>
+            <aliasEnabled>false</aliasEnabled>
+        </bulkCriteria>
+        <bulkCriteria>
+            <exactCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingBirthDateDuplicateCriteria</exactCriteriaName>
+            <exactEnabled>true</exactEnabled>
+            <aliasCriteriaName>uk.gov.ch.chips.server.director.search.bulk.MissingBirthDateDuplicateAliasCriteria</aliasCriteriaName>
+            <aliasEnabled>false</aliasEnabled>
+        </bulkCriteria>
+        <bulkCriteria>
+            <exactCriteriaName>uk.gov.ch.chips.server.director.search.bulk.FuzzyNameAndStreetDuplicateCriteria</exactCriteriaName>
+            <exactEnabled>true</exactEnabled>
+            <aliasEnabled>false</aliasEnabled>
+        </bulkCriteria>
+    </bulkCriterias>
+</officer-bulk-configuration>

--- a/weblogic-batch/officer-bulk-process/check--10000-exists.sh
+++ b/weblogic-batch/officer-bulk-process/check--10000-exists.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#       PURPOSE: A cronned script to warn CSI that the Publish stage left a -10000 row pair in chipstab.officer_detail_match
+#                If that happens, just delete it !
+
+cd /apps/oracle/officer-bulk-process
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst <../.msmtprc.template >../.msmtprc
+source ../scripts/alert_functions
+
+## Check to make sure we did not leave after PUBLISH stage any -10000 WORK_ITEM_REFERENCE
+./check-officer-publish-finished.command
+
+if [ $? -gt 0 ]; then
+    echo "Non-zero exit code for check-officer-publish-finished.command"
+    email_CHAPS_group_f " $(basename $0): Fix Zombie Officer in chipstab.officer_detail_match- Bulk Officer Job."
+    exit 1
+fi

--- a/weblogic-batch/officer-bulk-process/check-bpp-timestamps-order.command
+++ b/weblogic-batch/officer-bulk-process/check-bpp-timestamps-order.command
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+EXPECTED_RESULT=$1
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+        set head off;
+        select key
+        from chipstab.batch_process_parameters
+        where domain = 'CHIPS'
+        and sub_domain = 'DIRECTORS'
+        and subject_area = 'PARAMETERS'
+        and key like 'BULK_%_TMSP'
+        order by param_val asc;
+EOF`
+
+RESULT=`echo ${OUTPUT} | sed 's/ $//g'`
+
+if [[ "${RESULT}" != "${EXPECTED_RESULT}" ]]; then
+        echo "DB params order ${RESULT} does not match expected order ${EXPECTED_RESULT}"
+        exit 1
+fi
+
+exit 0

--- a/weblogic-batch/officer-bulk-process/check-lock-file-reminder.sh
+++ b/weblogic-batch/officer-bulk-process/check-lock-file-reminder.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#       PURPOSE: A cronned script to warn CSI that we forgot to take Lock File off
+
+cd /apps/oracle/officer-bulk-process
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst <../.msmtprc.template >../.msmtprc
+source ../scripts/alert_functions
+
+if [ -f /apps/oracle/officer-bulk-process/OFFICER_LOCK_FILE_ALERT ]; then
+    email_CHAPS_group_f " $(pwd)/$(basename $0): HEADS UP - OFFICER_LOCK_FILE_ALERT exists. Remove if needed !!!"
+    exit 1
+fi

--- a/weblogic-batch/officer-bulk-process/check-officer-merge-finished.command
+++ b/weblogic-batch/officer-bulk-process/check-officer-merge-finished.command
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+       set head off;
+       select distinct(1) from chipstab.officer_event_match ;
+EOF`
+
+OUTPUT=`echo "${OUTPUT}" | head -2`
+RESULT=`echo ${OUTPUT} | sed 's/ //g'`
+
+## if we have a 1 returned, then we could have an error - exit 1 for parent script
+[ ${RESULT} = "1" ] && exit 1
+
+exit 0

--- a/weblogic-batch/officer-bulk-process/check-officer-publish-finished.command
+++ b/weblogic-batch/officer-bulk-process/check-officer-publish-finished.command
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+OUTPUT=`sqlplus  -s ${CHIPS_SQLPLUS_CONN_STRING} << EOF
+       set head off;
+       select count(*) from chipstab.officer_detail_match o where o.WORK_ITEM_REFERENCE = -10000;
+EOF`
+
+OUTPUT=`echo "${OUTPUT}" | head -2`
+RESULT=`echo ${OUTPUT} | sed 's/ //g'`
+
+echo "Rows in OFFICER_DETAIL_MATCH with WORK_ITEM_REFERENCE = -10000: ${OUTPUT}"
+
+(( $RESULT > 10 )) && exit 1
+
+exit 0

--- a/weblogic-batch/officer-bulk-process/log4j2.xml
+++ b/weblogic-batch/officer-bulk-process/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} [%c{1}] %-5level - %m%n" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.apache.log4j.xml" level="debug" />
+        <Root level="debug">
+            <AppenderRef ref="ConsoleAppender" />
+        </Root>
+
+        <Logger name="org.springframework" level="info" additivity="false">
+            <AppenderRef ref="ConsoleAppender"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+function check_error_lock_file {
+        if [ -f /apps/oracle/officer-bulk-process/OFFICER_LOCK_FILE_ALERT ]; then
+                echo "OFFICER_LOCK_FILE_ALERT exists. Previous run failed."
+                email_CHAPS_group_f " $(pwd)/$(basename $0): OFFICER_LOCK_FILE_ALERT exists. Previous run failed."
+                exit 1
+        fi
+}
+
+function set_error_lock_file {
+        touch /apps/oracle/officer-bulk-process/OFFICER_LOCK_FILE_ALERT
+}
+
+function remove_running_lock_file {
+        rm /apps/oracle/officer-bulk-process/OFFICER_RUNNING
+}
+
+function set_running_lock_file {
+        touch /apps/oracle/officer-bulk-process/OFFICER_RUNNING
+}
+
+function check_running_lock_file {
+        if [ -f /apps/oracle/officer-bulk-process/OFFICER_RUNNING ]; then
+                echo "OFFICER_RUNNING lock file exists. Officer already running."
+                email_CHAPS_group_f " $(pwd)/$(basename $0): OFFICER_RUNNING lock file exists. Officer already running."
+                exit 1
+        fi
+}
+
+cd /apps/oracle/officer-bulk-process
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# create properties file and substitutes values
+envsubst <officer-poller.properties.template >officer-poller.properties
+
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/xstream.jar:/apps/oracle/libs/cglib-nodep.jar:/apps/oracle/libs/joda-time.jar:/apps/oracle/libs/commons-lang.jar:/apps/oracle/libs/ojdbc8.jar:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/spring.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-1.2-api.jar:/apps/oracle/officer-bulk-process/officer-bulk-process.jar
+
+# Set up mail config for msmtp & load alerting functions
+envsubst <../.msmtprc.template >../.msmtprc
+source ../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../logs/officer-bulk-process
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-officer-bulk-process-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >>${LOG_FILE} 2>&1
+
+echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+if [[ $# > 1 ]]; then
+        echo "$(date) Failed to start officer-bulk-process: Too many parameters, options are 123 | 2 | 3 | 23"
+        exit 1
+fi
+
+# default to running all three stages
+RUN_STAGE_ONE="true"
+RUN_STAGE_TWO="true"
+RUN_STAGE_THREE="true"
+
+case $1 in
+"123" | "") ;;
+"2")
+        RUN_STAGE_ONE="false"
+        RUN_STAGE_THREE="false"
+        ;;
+"3")
+        RUN_STAGE_ONE="false"
+        RUN_STAGE_TWO="false"
+        ;;
+"23")
+        RUN_STAGE_ONE="false"
+        ;;
+*)
+        echo "$(date) Failed to start officer-bulk-process: Unknown parameter value, options are 123 | 2 | 3 | 23"
+        exit 1
+        ;;
+esac
+
+echo -n "$(date) Starting officer-bulk-process: Running stage(s) "
+if [[ ${RUN_STAGE_ONE} == "true" ]]; then echo -n "ONE "; fi
+if [[ ${RUN_STAGE_TWO} == "true" ]]; then echo -n "TWO "; fi
+if [[ ${RUN_STAGE_THREE} == "true" ]]; then echo -n "THREE "; fi
+echo
+
+## Check if previous run has failed or job already running, exit and alert
+check_error_lock_file
+check_running_lock_file
+
+## Set running file to prevent duplicate running
+set_running_lock_file
+
+## Check to make sure we did not time out on previous PUBLISH stage i.e. are there any -10000 WORK_ITEM_REFERENCE
+echo Running check to make sure we did not time out on previous PUBLISH stage
+./check-officer-publish-finished.command
+
+if [ $? -gt 0 ]; then
+        echo "Non-zero exit code for check-officer-publish-finished.command"
+        remove_running_lock_file
+        set_error_lock_file
+        email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-publish-finished.command. "
+        exit 1
+fi
+
+## REAL WORK BEGINS
+
+if [[ ${RUN_STAGE_ONE} == "true" ]]; then
+        echo Running reset Batch process parameters
+        ./reset-director-bpp.command
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for reset-director-bpp.command "
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for reset-director-bpp.command. "
+                exit 1
+        fi
+
+        ## Run FIRST stage of Officer job - EVENT
+        echo "Run FIRST stage of Officer job - EVENT  - normal mode"
+
+        /usr/java/jdk-8/bin/java -Din=officer-bulk-process -cp $CLASSPATH -Dlog4j.configurationFile=log4j2.xml \
+                uk.gov.companieshouse.officerbulkprocess.OfficerDetailEventPoller normal ${JMS_JNDIPROVIDERURL} bulk-officer.xml
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for FIRST stage officer java execution"
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for FIRST stage officer java execution. "
+                exit 1
+        fi
+
+        echo
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo "Zero return code for FIRST stage of Officer job - EVENT. Exit probably successful"
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo
+
+        if [[ ${RUN_STAGE_TWO} == "true" || ${RUN_STAGE_THREE} == "true" ]]; then
+                ## Sleep after job returns as processing is still going on in server
+                sleep 1800 # 30 min
+        fi
+
+fi
+
+if [[ ${RUN_STAGE_TWO} == "true" ]]; then
+
+        ## Run SECOND stage of Officer job - MERGE
+        echo "Run SECOND stage of Officer job - MERGE - catchup mode"
+        /usr/java/jdk-8/bin/java -Din=officer-bulk-process -cp $CLASSPATH -Dlog4j.configurationFile=log4j2.xml \
+                uk.gov.companieshouse.officerbulkprocess.OfficerDetailEventPoller catchup ${JMS_JNDIPROVIDERURL} bulk-officer.xml
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for SECOND stage officer java execution"
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for SECOND stage officer java execution. "
+                exit 1
+        fi
+
+        echo
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo "Zero return code for SECOND stage of Officer job - MERGE. Exit probably successful"
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo
+
+        if [[ ${RUN_STAGE_THREE} == "true" ]]; then
+                ## Sleep after job returns as processing is still going on in server
+                sleep 1800 # 30 min
+        fi
+
+fi
+
+if [[ ${RUN_STAGE_THREE} == "true" ]]; then
+
+        ## Check to make sure we cleared OFFICER_EVENT_MATCH on previous MERGE stage i.e. are there any rows left in OFFICER_EVENT_MATCH
+        echo Running check to make sure we did finish MERGE stage
+        ./check-officer-merge-finished.command
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-officer-merge-finished.command "
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-merge-finished.command. "
+                exit 1
+        fi
+
+        ## Run THIRD stage of Officer job - PUBLISH
+        echo "Run THIRD stage of Officer job - PUBLISH - catchup mode"
+        /usr/java/jdk-8/bin/java -Din=officer-bulk-process -cp $CLASSPATH -Dlog4j.configurationFile=log4j2.xml \
+                uk.gov.companieshouse.officerbulkprocess.OfficerDetailEventPoller catchup ${JMS_JNDIPROVIDERURL} bulk-officer.xml
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for THIRD stage officer java execution"
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for officer java execution. "
+                exit 1
+        fi
+
+        echo
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo "Zero return code for THIRD stage of Officer job - PUBLISH. Exit probably successful"
+        echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        echo
+
+fi
+
+## Remove running lock file
+remove_running_lock_file
+
+echo $(date) Ending officer-bulk-process
+echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
@@ -121,6 +121,17 @@ if [[ ${RUN_STAGE_ONE} == "true" ]]; then
                 exit 1
         fi
 
+        ## Check that BPP timestamp order is as expected for EVENT stage
+        ./check-bpp-timestamps-order.command "BULK_EVENT_TMSP BULK_MERGE_TMSP BULK_PUB_TMSP"
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                exit 1
+        fi
+
         ## Run FIRST stage of Officer job - EVENT
         echo "Run FIRST stage of Officer job - EVENT  - normal mode"
 
@@ -150,6 +161,17 @@ fi
 
 if [[ ${RUN_STAGE_TWO} == "true" ]]; then
 
+        ## Check that BPP timestamp order is as expected for MERGE stage
+        ./check-bpp-timestamps-order.command "BULK_MERGE_TMSP BULK_PUB_TMSP BULK_EVENT_TMSP"
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                exit 1
+        fi
+
         ## Run SECOND stage of Officer job - MERGE
         echo "Run SECOND stage of Officer job - MERGE - catchup mode"
         /usr/java/jdk-8/bin/java -Din=officer-bulk-process -cp $CLASSPATH -Dlog4j.configurationFile=log4j2.xml \
@@ -177,6 +199,17 @@ if [[ ${RUN_STAGE_TWO} == "true" ]]; then
 fi
 
 if [[ ${RUN_STAGE_THREE} == "true" ]]; then
+
+        ## Check that BPP timestamp order is as expected for PUBLISH stage
+        ./check-bpp-timestamps-order.command "BULK_PUB_TMSP BULK_EVENT_TMSP BULK_MERGE_TMSP"
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-bpp-timestamps-order.command - BPP timestamp order not as expected "
+                exit 1
+        fi
 
         ## Check to make sure we cleared OFFICER_EVENT_MATCH on previous MERGE stage i.e. are there any rows left in OFFICER_EVENT_MATCH
         echo Running check to make sure we did finish MERGE stage

--- a/weblogic-batch/officer-bulk-process/officer-poller.properties.template
+++ b/weblogic-batch/officer-bulk-process/officer-poller.properties.template
@@ -1,0 +1,15 @@
+-- **********************************************************
+-- JMS configuration for the anticipated live environment
+
+-- **********************************************************
+
+jms.jndiContextFactory=${JMS_JNDICONTEXTFACTORY}
+
+jms.queueConnectionFactoryName=${JMS_QUEUECONNECTIONFACTORYNAME}
+jms.queueName=${JMS_OFFICEREVENTQUEUE}
+
+-- should ALWAYS be false for the live environment
+officer.contextProxyEnabled=false
+
+-- database jndi name
+db.datasource=chipsBulkDS

--- a/weblogic-batch/officer-bulk-process/reset-director-bpp.command
+++ b/weblogic-batch/officer-bulk-process/reset-director-bpp.command
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+sqlplus -s -L ${CHIPS_SQLPLUS_CONN_STRING} <<EOF
+  alter session set current_schema=chipstab;
+  set head off;
+  set serveroutput on;
+  WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+  DECLARE
+   v_day_of_week           NUMBER (1) := 0;
+   v_date_increase         NUMBER (2) := 1;
+  BEGIN
+
+  select to_char(sysdate,'D') into v_day_of_week from dual;
+  v_date_increase := 1;
+
+  update batch_process_parameters
+  set param_val = TO_CHAR((to_date(param_val,'DD/MM/YYYY HH24:MI:ss')+v_date_increase) - INTERVAL '45' MINUTE, 'DD/MM/YYYY HH24:MI:SS')
+  where  key = 'BULK_EVENT_TMSP';
+
+  update batch_process_parameters
+  set param_val = TO_CHAR((to_date(param_val,'DD/MM/YYYY HH24:MI:ss')+v_date_increase) - INTERVAL '60' MINUTE, 'DD/MM/YYYY HH24:MI:SS')
+  where  key = 'BULK_MERGE_TMSP';
+
+  update batch_process_parameters
+  set param_val = TO_CHAR((to_date(param_val,'DD/MM/YYYY HH24:MI:ss')+v_date_increase) - INTERVAL '60' MINUTE, 'DD/MM/YYYY HH24:MI:SS')
+  where  key = 'BULK_PUB_TMSP';
+
+  COMMIT;
+  END;
+  /
+EOF
+
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+  echo "Failed to reset director batch process parameters: SQLERROR with SQL.SQLCODE $exit_code"
+  exit 1
+fi
+
+exit 0

--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -66,7 +66,7 @@ email_CHAPS_group_f ()
 {
   if check_email_address_defined_f; then
     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
-    echo -e "To:${EMAIL_ADDRESS_SERVICENOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_SERVICE_NOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
   fi
 }
 


### PR DESCRIPTION
Initial commit to add officer scripts to weblogic batch (crontab entries
commented out for now).

Main script officer-bulk-process.sh is copied from existing script
officer.catchup.sh, but added an optional parameter so that current
scripts for partial runs can use the main script (e.g. calling
"./officer-bulk-process.sh 23" replaces the current
officer.catchup.STAGE.2.3.sh).

Also fixed a typo (missing underscore in the property name
EMAIL_ADDRESS_SERVICE_NOW) in alert_functions script.