### PR TITLE
Only check PUBLISH stage finished in EVENT stage

### DIFF
--- a/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
@@ -95,21 +95,22 @@ check_running_lock_file
 ## Set running file to prevent duplicate running
 set_running_lock_file
 
-## Check to make sure we did not time out on previous PUBLISH stage i.e. are there any -10000 WORK_ITEM_REFERENCE
-echo Running check to make sure we did not time out on previous PUBLISH stage
-./check-officer-publish-finished.command
-
-if [ $? -gt 0 ]; then
-        echo "Non-zero exit code for check-officer-publish-finished.command"
-        remove_running_lock_file
-        set_error_lock_file
-        email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-publish-finished.command. "
-        exit 1
-fi
-
 ## REAL WORK BEGINS
 
 if [[ ${RUN_STAGE_ONE} == "true" ]]; then
+
+        ## Check to make sure we did not time out on previous PUBLISH stage i.e. are there any -10000 WORK_ITEM_REFERENCE
+        echo Running check to make sure we did not time out on previous PUBLISH stage
+        ./check-officer-publish-finished.command
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-officer-publish-finished.command"
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-publish-finished.command. "
+                exit 1
+        fi
+
         echo Running reset Batch process parameters
         ./reset-director-bpp.command
 


### PR DESCRIPTION
Moving check for completed PUBLISH stage inside stage 1 (event) section to allow for deliberate retry attempts (e.g. re-running stage 3 in isolation when this is in an incomplete state).