### PR TITLE
CM-1106 Letter producer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/image-regeneration/1.2.5/image-regeneration-1.2.5.jar -o ../image-regeneration/image-regeneration.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/letter-producer/1.1.1/letter-producer-1.1.1.jar -o ../letter-producer/letter-producer.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/officer-bulk-process/1.0.5/officer-bulk-process-1.0.5.jar -o ../officer-bulk-process/officer-bulk-process.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/psc-pursuit-trigger/1.9.1/psc-pursuit-trigger-1.9.1.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
     chmod -R 750 ${ORACLE_HOME}/*

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -20,3 +20,7 @@
 30 15 * * * $HOME/officer-bulk-process/check-lock-file-reminder.sh
 ## Check Zombie Officer in chipstab.officer_detail_match
 30 15 * * * $HOME/officer-bulk-process/check--10000-exists.sh 2>&1 >/dev/null
+
+## letter-counts that follow letter-producer
+# 00 06 * * 1 $HOME/letter-producer/bad-letters.sh
+# 15 04 * * 2-6 $HOME/letter-producer/letter-counts.sh

--- a/weblogic-batch/image-regeneration/fesImageRegenerateClient.sh
+++ b/weblogic-batch/image-regeneration/fesImageRegenerateClient.sh
@@ -20,17 +20,20 @@
 #  A log file, called <filename>.log will be created.
 #
 # =============================================================================
+
 transactionIdsFile=transaction_ids
 scriptLogFile=${transactionIdsFile}.log
+
+source /apps/oracle/scripts/logging_functions
 
 ./image-regeneration.sh fes_image_regen ${transactionIdsFile} >  ${scriptLogFile} 2>&1
 status=$?
 
-if [ $status -gt 0 ]; then
-    echo "Non-zero exit code for fesImageRegenerateClient.sh execution. Check the script log file for error details: ${scriptLogFile}"
+if [ $status -gt 0 ]
+then
+    f_logError "Non-zero exit code of %s for fesImageRegenerateClient.sh execution. Check the script log file for error details: %s" ${status} ${scriptLogFile}
     exit 1
 else 
-    echo "Successfully completed fesImageRegenerateClient.sh execution. Check the script log file for results: ${scriptLogFile}"
+    f_logInfo "Successfully completed fesImageRegenerateClient.sh execution. Check the script log file for results: %s" ${scriptLogFile}
 fi
-
 

--- a/weblogic-batch/image-regeneration/imageRegenerateClient.sh
+++ b/weblogic-batch/image-regeneration/imageRegenerateClient.sh
@@ -20,16 +20,20 @@
 #  A log file, called <filename>.log will be created.
 #
 # =============================================================================
+
 transactionIdsFile=transaction_ids
 scriptLogFile=${transactionIdsFile}.log
+
+source /apps/oracle/scripts/logging_functions
 
 ./image-regeneration.sh standard_image_regen ${transactionIdsFile} >  ${scriptLogFile} 2>&1
 status=$?
 
-if [ $status -gt 0 ]; then
-    echo "Non-zero exit code for imageRegenerateClient.sh execution. Check the script log file for error details: ${scriptLogFile}"
+if [ $status -gt 0 ]
+then
+    f_logError "Non-zero exit code of %s for imageRegenerateClient.sh execution. Check the script log file for error details: %s" ${status} ${scriptLogFile}
     exit 1
 else 
-    echo "Successfully completed imageRegenerateClient.sh execution. Check the script log file for results: ${scriptLogFile}"
+    f_logInfo "Successfully completed imageRegenerateClient.sh execution. Check the script log file for results: %s" ${scriptLogFile}
 fi
 

--- a/weblogic-batch/letter-producer/bad-letters.sh
+++ b/weblogic-batch/letter-producer/bad-letters.sh
@@ -15,16 +15,14 @@ source ../scripts/alert_functions
 LOGS_DIR=../logs/letter-producer
 mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-bad-letters-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
 
 exec >> ${LOG_FILE} 2>&1
 
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-echo `date` Starting bad-letters
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting bad-letters"
 
-# TODO: below here needs to be re-worked for cloud migration:
-#   - considering directory / mount availablity
-
-cd $HOME/wlenvp1domain/batch/letterProducerOutput
+cd /apps/oracle/chipsdomain/batch/letterProducerOutput
 
 find . -name '*.xml' -type f -print | grep -v large_font | grep -v schedule |  grep -v DissCerts | grep '_'>/tmp/bad_letters
 
@@ -32,7 +30,7 @@ cut -c30-39 /tmp/bad_letters>/tmp/bad_letter_id
 
 cat /tmp/bad_letter_id
 
-email_report_CHAPS_group_f ("Weekly Bad Letter Ids","`cat /tmp/bad_letter_id`")
+email_report_CHAPS_group_f "Weekly Bad Letter Ids" "`cat /tmp/bad_letter_id`"
 
-echo `date` Ending bad-letters
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+f_logInfo "Ending bad-letters"
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/weblogic-batch/letter-producer/bad-letters.sh
+++ b/weblogic-batch/letter-producer/bad-letters.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+cd /apps/oracle/letter-producer
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst < ../.msmtprc.template > ../.msmtprc
+source ../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../logs/letter-producer
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-bad-letters-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >> ${LOG_FILE} 2>&1
+
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+echo `date` Starting bad-letters
+
+# TODO: below here needs to be re-worked for cloud migration:
+#   - considering directory / mount availablity
+
+cd $HOME/wlenvp1domain/batch/letterProducerOutput
+
+find . -name '*.xml' -type f -print | grep -v large_font | grep -v schedule |  grep -v DissCerts | grep '_'>/tmp/bad_letters
+
+cut -c30-39 /tmp/bad_letters>/tmp/bad_letter_id
+
+cat /tmp/bad_letter_id
+
+email_report_CHAPS_group_f ("Weekly Bad Letter Ids","`cat /tmp/bad_letter_id`")
+
+echo `date` Ending bad-letters
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/letter-producer/letter-counts.sh
+++ b/weblogic-batch/letter-producer/letter-counts.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+cd /apps/oracle/letter-producer
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst < ../.msmtprc.template > ../.msmtprc
+source ../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../logs/letter-producer
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-letter-counts-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >> ${LOG_FILE} 2>&1
+
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+echo `date` Starting letter-counts
+DATE=`date +%Y-%m-%d`
+
+# TODO: below here needs to be re-worked for cloud migration:
+#   - considering directory / mount availablity
+
+DIR=`ls -d $HOME/wlenvp1domain/batch/doc1ProducerOutput/$DATE*`
+
+#Non zero exit code
+if [ ! $? -eq 0 ] ; then
+  email_CHAPS_group_f "Daily Letters Produced: Overrun or Failed" "Due to overun or failure, cannot find directory yet for date ${DATE}"
+  exit 1
+fi
+
+echo "$DIR"
+cd "$DIR"
+
+#Clear letter_tots file
+>/tmp/letter_tots
+
+# SCOTLAND and SVOL are not excluded
+for FILE in `find . -name '*' -print |  grep -v ERROR | grep -v SCDOC1CES | grep -v WSOLE | grep -v WSOLW | grep -v 'CERTSSC.TXT' | grep -v 'CHVOLCER/RETCERT' | grep -v 'CHVOLCER/DOC1CES' | grep -v 'NIRETCERT' | grep -v 'NIDOC1CES' | grep -v 'DEF49EW' | grep -v 'WDEF49EW' | grep -v 'NIDEF49' | grep -v 'MORTEW' | grep -v 'MORTBI' | grep -v 'MORTSC' | grep -v 'MORTNI' `
+do
+  #If $FILE is a file not a directory
+  if [ -f "$FILE" ] ; then
+    #strip off leading path
+    FILENAME=`basename "$FILE"`
+    echo "$FILE":`grep -c 107000 $FILE` | tee -a /tmp/letter_tots
+  fi
+done
+
+#Sort file, and strip out leading dot slash (./)
+sort /tmp/letter_tots | sed 's/.\///' > /tmp/letter_no_tots
+
+email_report_CHAPS_group_f ("Daily Letters File Sent to APS","`cat /tmp/letter_no_tots`")
+
+echo `date` Ending letter-counts
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/letter-producer/letter-counts.sh
+++ b/weblogic-batch/letter-producer/letter-counts.sh
@@ -15,17 +15,15 @@ source ../scripts/alert_functions
 LOGS_DIR=../logs/letter-producer
 mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-letter-counts-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
 
 exec >> ${LOG_FILE} 2>&1
 
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-echo `date` Starting letter-counts
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting letter-counts"
 DATE=`date +%Y-%m-%d`
 
-# TODO: below here needs to be re-worked for cloud migration:
-#   - considering directory / mount availablity
-
-DIR=`ls -d $HOME/wlenvp1domain/batch/doc1ProducerOutput/$DATE*`
+DIR=`ls -d /apps/oracle/chipsdomain/batch/doc1ProducerOutput/$DATE*`
 
 #Non zero exit code
 if [ ! $? -eq 0 ] ; then
@@ -33,7 +31,7 @@ if [ ! $? -eq 0 ] ; then
   exit 1
 fi
 
-echo "$DIR"
+f_logInfo "$DIR"
 cd "$DIR"
 
 #Clear letter_tots file
@@ -53,7 +51,7 @@ done
 #Sort file, and strip out leading dot slash (./)
 sort /tmp/letter_tots | sed 's/.\///' > /tmp/letter_no_tots
 
-email_report_CHAPS_group_f ("Daily Letters File Sent to APS","`cat /tmp/letter_no_tots`")
+email_report_CHAPS_group_f "Daily Letters File Sent to APS" "`cat /tmp/letter_no_tots`"
 
-echo `date` Ending letter-counts
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+f_logInfo "Ending letter-counts"
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/weblogic-batch/letter-producer/letter-producer.properties.template
+++ b/weblogic-batch/letter-producer/letter-producer.properties.template
@@ -1,0 +1,3 @@
+letterProducer.provider.url=${JMS_JNDIPROVIDERURL}
+letterProducer.security.principal=${WEBLOGIC_ADMIN_USERNAME}
+letterProducer.security.credentials=${ADMIN_PASSWORD}

--- a/weblogic-batch/letter-producer/letter-producer.sh
+++ b/weblogic-batch/letter-producer/letter-producer.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cd /apps/oracle/letter-producer
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# create properties file and substitutes values
+envsubst < letter-producer.properties.template > letter-producer.properties
+
+# TODO: review / confirm classpath requirements
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/letter-producer/letter-producer.jar
+
+# Set up mail config for msmtp & load alerting functions
+envsubst < ../.msmtprc.template > ../.msmtprc
+source ../scripts/alert_functions
+
+#TODO: consider how logging will be handled - here or process compliance or both? (tee like image regen?)
+# set up logging
+LOGS_DIR=../logs/letter-producer
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-letter-producer-$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+exec >> ${LOG_FILE} 2>&1
+
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+echo `date` Starting letter-producer
+
+#TODO: this will probably be moved to controlling script in process compliance
+echo Checking that letter-producer is not already running
+../scripts/check-for-jms-message.sh ${JMS_LETTERPRODUCERQUEUE}
+if [ $? -gt 0 ]; then
+        echo `date`": letter-producer may be already running or connection error.  Please investigate."
+        patrol_log_alert_chaps_f " `pwd`/`basename $0`:  letter-producer may be already running or connection error.  Please investigate."
+        exit 1
+fi
+
+/usr/java/jdk-8/bin/java -Din=letter-producer -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.letterproducer.LetterProducerRunner letter-producer.properties
+if [ $? -gt 0 ]; then
+        echo "Non-zero exit code for letter-producer java execution"
+        exit 1
+fi
+
+echo `date` Ending letter-producer
+echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/weblogic-batch/letter-producer/letter-producer.sh
+++ b/weblogic-batch/letter-producer/letter-producer.sh
@@ -10,38 +10,38 @@ HOME=${KEEP_HOME}
 # create properties file and substitutes values
 envsubst < letter-producer.properties.template > letter-producer.properties
 
-# TODO: review / confirm classpath requirements
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/letter-producer/letter-producer.jar
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/letter-producer/letter-producer.jar
 
 # Set up mail config for msmtp & load alerting functions
-envsubst < ../.msmtprc.template > ../.msmtprc
-source ../scripts/alert_functions
+envsubst < /apps/oracle/.msmtprc.template > /apps/oracle/.msmtprc
+source /apps/oracle/scripts/alert_functions
 
-#TODO: consider how logging will be handled - here or process compliance or both? (tee like image regen?)
+#TODO as part of process compliance script: consider how logging will be handled - here or process compliance or both? (tee like image regen?)
 # set up logging
 LOGS_DIR=../logs/letter-producer
 mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-letter-producer-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
 
 exec >> ${LOG_FILE} 2>&1
 
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-echo `date` Starting letter-producer
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting letter-producer"
 
-#TODO: this will probably be moved to controlling script in process compliance
-echo Checking that letter-producer is not already running
+#TODO as part of process compliance script: keep here or move to controlling script in process compliance?
+f_logInfo "Checking that letter-producer is not already running"
 ../scripts/check-for-jms-message.sh ${JMS_LETTERPRODUCERQUEUE}
 if [ $? -gt 0 ]; then
-        echo `date`": letter-producer may be already running or connection error.  Please investigate."
+        f_logError "letter-producer may be already running or connection error.  Please investigate."
         patrol_log_alert_chaps_f " `pwd`/`basename $0`:  letter-producer may be already running or connection error.  Please investigate."
         exit 1
 fi
 
 /usr/java/jdk-8/bin/java -Din=letter-producer -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.letterproducer.LetterProducerRunner letter-producer.properties
 if [ $? -gt 0 ]; then
-        echo "Non-zero exit code for letter-producer java execution"
+        f_logError "Non-zero exit code for letter-producer java execution"
         exit 1
 fi
 
-echo `date` Ending letter-producer
-echo  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+f_logInfo "Ending letter-producer"
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process-single.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process-single.sh
@@ -9,7 +9,7 @@
 #   update OFFICER_EVENT_MATCH o set o.EVENT_TMSP=to_date('28-MAR-2008','DD-MON-YYYY')  -- this is Catchup date
 #   where o.EVENT_TMSP = to_date('04-DEC-2008 13:31:26','DD-MON-YYYY HH24:MI:SS')       -- this is runtime (Today) date
 #
-#   After this run, then you just run normal Officer Catchup, which will pick these up.
+#   After this run, then you just run normal Officer Catchup (stages 2 & 3), which will pick these up.
 
 function check_error_lock_file {
   if [ -f /apps/oracle/officer-bulk-process/OFFICER_LOCK_FILE_ALERT ]; then

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
@@ -95,21 +95,22 @@ check_running_lock_file
 ## Set running file to prevent duplicate running
 set_running_lock_file
 
-## Check to make sure we did not time out on previous PUBLISH stage i.e. are there any -10000 WORK_ITEM_REFERENCE
-echo Running check to make sure we did not time out on previous PUBLISH stage
-./check-officer-publish-finished.command
-
-if [ $? -gt 0 ]; then
-        echo "Non-zero exit code for check-officer-publish-finished.command"
-        remove_running_lock_file
-        set_error_lock_file
-        email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-publish-finished.command. "
-        exit 1
-fi
-
 ## REAL WORK BEGINS
 
 if [[ ${RUN_STAGE_ONE} == "true" ]]; then
+
+        ## Check to make sure we did not time out on previous PUBLISH stage i.e. are there any -10000 WORK_ITEM_REFERENCE
+        echo Running check to make sure we did not time out on previous PUBLISH stage
+        ./check-officer-publish-finished.command
+
+        if [ $? -gt 0 ]; then
+                echo "Non-zero exit code for check-officer-publish-finished.command"
+                remove_running_lock_file
+                set_error_lock_file
+                email_CHAPS_group_f " $(pwd)/$(basename $0): Non-zero exit code for check-officer-publish-finished.command. "
+                exit 1
+        fi
+
         echo Running reset Batch process parameters
         ./reset-director-bpp.command
 

--- a/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
+++ b/weblogic-batch/psc-pursuit-trigger/psc-pursuit-trigger.sh
@@ -1,52 +1,17 @@
 #!/bin/bash
 
-# =============================================================================
-# Arguments:
-#              arg 1 =        log template
-#              remainder arguments = parameters for logging
-# =============================================================================
-function f_logInfo {
-  f_log "INFO" "$@"
-}
-
-# =============================================================================
-# Arguments:
-#              arg 1 =        log template
-#              remainder arguments = parameters for logging
-# =============================================================================
-function f_logError {
-  f_log "ERROR" "$@"
-}
-
-# =============================================================================
-# Arguments:
-#              arg 1 =        log level.
-#              arg 2 =        log template
-#              remainder arguments = parameters for logging
-# =============================================================================
-function f_log {
-  typeset logLevel=$1; shift
-  typeset logTemplate=$1; shift
-  printf "%-24s %-5s $logTemplate\n" "$(date --iso-8601=seconds)" "$logLevel"  "$@"  
-}
-
-cd /apps/oracle/psc-pursuit-trigger || f_logError "psc-pursuit-trigger directory error" || exit 1
-
 # load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
 KEEP_HOME=${HOME}
 source /apps/oracle/env.variables
 HOME=${KEEP_HOME}
 
-# create properties file and substitutes values
-envsubst < psc-pursuit-trigger.properties.template > psc-pursuit-trigger.properties
-
 LIBS_DIR=/apps/oracle/libs
 CLASSPATH=${CLASSPATH}:.:${LIBS_DIR}/log4j-api.jar:${LIBS_DIR}/log4j-core.jar:${LIBS_DIR}/ojdbc8.jar:/apps/oracle/psc-pursuit-trigger/psc-pursuit-trigger.jar
 
 # Set up mail config for msmtp & load alerting functions
-envsubst < ../.msmtprc.template > ../.msmtprc
+envsubst < /apps/oracle/.msmtprc.template > /apps/oracle/.msmtprc
 source /apps/oracle/scripts/alert_functions
-
+source /apps/oracle/scripts/logging_functions
 
 # set up logging
 LOGS_DIR=/apps/oracle/logs/psc-pursuit-trigger
@@ -55,16 +20,22 @@ LOG_FILE="${LOGS_DIR}/${HOSTNAME}-psc-pursuit-trigger-$(date +'%Y-%m-%d_%H-%M-%S
 
 exec >> "${LOG_FILE}" 2>&1
 
+cd /apps/oracle/psc-pursuit-trigger || { f_logError "psc-pursuit-trigger directory error" ; exit 1 ; }
+
+# create properties file and substitutes values
+envsubst < psc-pursuit-trigger.properties.template > psc-pursuit-trigger.properties
+
 f_logInfo  "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 f_logInfo "Starting psc-pursuit-trigger"
 
 /usr/java/jdk-8/bin/java -Din=psc-pursuit-trigger -cp "${CLASSPATH}" -Dlog4j.configurationFile=log4j2.xml uk.gov.companieshouse.psc.pursuit.trigger.PscPursuitTrigger psc-pursuit-trigger.properties
 
 exit_code=$?
-if [ $exit_code -gt 0 ]; then
-        f_logError "Non-zero exit code for psc-pursuit-trigger java execution. The exit code was %s." "${exit_code}"
-        email_CHAPS_group_f "psc-pursuit-trigger failed. " "$(pwd)/$(basename "$0") psc-pursuit-trigger trigger exit code of ${exit_code} indicates failure. Please investigate."
-        exit 1
+if [ $exit_code -gt 0 ]
+then
+  f_logError "Non-zero exit code for psc-pursuit-trigger java execution. The exit code was %s." "${exit_code}"
+  email_CHAPS_group_f "psc-pursuit-trigger failed. " "$(pwd)/$(basename "$0") psc-pursuit-trigger trigger exit code of ${exit_code} indicates failure. Please investigate."
+  exit 1
 fi
 
 f_logInfo "Ending psc-pursuit-trigger"

--- a/weblogic-batch/scripts/check-for-jms-message.sh
+++ b/weblogic-batch/scripts/check-for-jms-message.sh
@@ -4,9 +4,11 @@ cd /apps/oracle/scripts
 
 # load variables created from setCron script if needed
 source /apps/oracle/env.variables
+# load logging functions
+source logging_functions
 
 if [ -z "$1" ]; then
-    echo `date`": Unable to confirm if process is already running on - no queue name passed as a parameter."
+    f_logError "Unable to confirm if process is already running - no queue name passed as a parameter."
     exit 1
 fi
 QUEUE_NAME=$1
@@ -18,18 +20,18 @@ CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs//
 UNPROCESSEDCOUNT=`/usr/java/jdk-8/bin/java -cp $CLASSPATH chaps.jms.JMSQueueStats ${JMS_SERVER_NAME}@${QUEUE_NAME} ${JMS_JNDIPROVIDERURL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD} | grep UNPROCESSED | awk -F: '{print $2}'`
 
 if [ -z "$UNPROCESSEDCOUNT" ]; then
-  echo `date`": Unable to confirm if process is already running on - possible issue with connection to Weblogic or other problem."
+  f_logError "Unable to confirm if process is already running - possible issue with connection to Weblogic or other problem."
   exit 1
 fi
 
 if [ "$UNPROCESSEDCOUNT" -eq 0 ]; then
-  echo `date`": OK. No unprocessed messages detected in ${QUEUE_NAME}."
+  f_logInfo "OK. No unprocessed messages detected in ${QUEUE_NAME}."
   exit 0
 fi
 
 ## if we find a message on 1p, process already running so exit one.
 if [ "$UNPROCESSEDCOUNT" -gt 0 ]; then
-  echo `date`": Message detected in ${QUEUE_NAME}.  Process still processing  ..."
+  f_logError "Message detected in ${QUEUE_NAME}.  Process still processing  ..."
   exit 1
 fi
 

--- a/weblogic-batch/scripts/logging_functions
+++ b/weblogic-batch/scripts/logging_functions
@@ -1,0 +1,67 @@
+#######################################################
+#
+# This file contains functions to assist production
+# of log output in a consistent manner for the Cloud
+# based Batch routines.
+#
+# Logging is sent to standard output so capture of
+# of the log is dependent upon calling script
+# directing standard output to the actual log files.
+#
+# This file should be sourced for functions to be used. 
+#
+#######################################################
+
+# =============================================================================
+# Arguments:
+#              arg 1 =        log template
+#              remainder arguments = parameters for logging
+#
+# Usage example:
+#
+# f_logInfo "Starting psc-pursuit-trigger"
+#
+# =============================================================================
+function f_logInfo {
+  f_log "INFO" "$@"
+}
+
+# =============================================================================
+# Arguments:
+#              arg 1 =        log template
+#              remainder arguments = parameters for logging
+#
+# Usage example:
+#
+# f_logError "Non-zero exit code for psc-pursuit-trigger java execution. The exit code was %s." "${exit_code}"
+#
+# =============================================================================
+function f_logError {
+  f_log "ERROR" "$@"
+}
+
+# =============================================================================
+# Arguments:
+#              arg 1 =        log template
+#              remainder arguments = parameters for logging
+#
+# Usage example:
+#
+# f_logWarn "Skipping first phase of job as not configured"
+#
+# =============================================================================
+function f_logWarn {
+  f_log "WARN" "$@"
+}
+
+# =============================================================================
+# Arguments:
+#              arg 1 =        log level
+#              arg 2 =        log template
+#              remainder arguments = parameters for logging
+# =============================================================================
+function f_log {
+  typeset logLevel=$1; shift
+  typeset logTemplate=$1; shift
+  printf "%-24s %-5s $logTemplate\n" "$(date --iso-8601=seconds)" "$logLevel"  "$@"  
+}


### PR DESCRIPTION
Note: PR one-way diff is confusing due to my merge from main branch before committing - for a clear diff between current main & feature/letter-producer branch ignoring merged commits, see https://github.com/companieshouse/chips-weblogic-batch/compare/main..feature/letter-producer

- Using /apps/oracle/chipsdomain/batch/ as path to output files - this
will need to be configured as a bind volume here & in wlserver
container(s) in docker-compose.yml; also requires chips.properties entry
  JMS_LETTERPRODUCERQUEUE="uk.gov.ch.chips.jms.LetterProducerQueue"

- Starting to use standard logging functions (incomplete: queries on
multi-line output & whether alert log file requires a specific format)

- Minor fixes for function call syntax

Some refactoring may be required when adding process compliance
co-ordinating script (marked as TODOs)

letter-counts.sh will need to be tested after doc1producer added
