### PR TITLE
CM-1105 Initial commit for compliance trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.1/jmstool-0.0.1.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/compliance-trigger/1.1.2/compliance-trigger-1.1.2.jar -o ../compliance-trigger/compliance-trigger.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/image-regeneration/1.2.5/image-regeneration-1.2.5.jar -o ../image-regeneration/image-regeneration.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/letter-producer/1.1.1/letter-producer-1.1.1.jar -o ../letter-producer/letter-producer.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/officer-bulk-process/1.0.5/officer-bulk-process-1.0.5.jar -o ../officer-bulk-process/officer-bulk-process.jar && \

--- a/weblogic-batch/compliance-trigger/compliance-trigger.properties.template
+++ b/weblogic-batch/compliance-trigger/compliance-trigger.properties.template
@@ -1,0 +1,24 @@
+#database properties to connect to the CHIPS database
+jdbc.deploy.url=${DB_URL_CHIPSDS}
+jdbc.deploy.username=${DB_USER_CHIPSDS}
+jdbc.deploy.password=${DB_PASSWORD_CHIPSDS}
+
+#database properties used for junit testing
+jdbc.test.url=jdbc:oracle:thin:@${jdbc.test.host}:${jdbc.test.port}:${jdbc.test.SID}
+jdbc.test.username=${jdbc.test.username}
+jdbc.test.password=${jdbc.test.password}
+
+#database properties to connect to the Staffware database
+jdbc.staffware.url=${DB_URL_STAFFDS}
+jdbc.staffware.username=${DB_USER_STAFFDS}
+jdbc.staffware.password=${DB_PASSWORD_STAFFDS}
+
+#compliance trigger configuration
+compliance.trigger.delay=${COMPLIANCE_TRIGGER_DELAY}
+compliance.trigger.ipdetect=${COMPLIANCE_TRIGGER_IPDETECT}
+compliance.trigger.pause=${COMPLIANCE_TRIGGER_PAUSE}
+compliance.trigger.eventlimit=${COMPLIANCE_TRIGGER_EVENTLIMIT}
+compliance.trigger.casesatonce=${COMPLIANCE_TRIGGER_CASESATONCE}
+
+#log4jConfig file location
+log4j.config=log4jconfig.xml

--- a/weblogic-batch/compliance-trigger/compliance-trigger.sh
+++ b/weblogic-batch/compliance-trigger/compliance-trigger.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+cd /apps/oracle/compliance-trigger
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# create properties file and substitutes values
+envsubst < compliance-trigger.properties.template > compliance-trigger.properties
+
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/log4j.jar:/apps/oracle/libs/ojdbc8.jar:/apps/oracle/compliance-trigger/compliance-trigger.jar
+
+# Set up mail config for msmtp & load alerting functions
+envsubst < /apps/oracle/.msmtprc.template > /apps/oracle/.msmtprc
+source /apps/oracle/scripts/alert_functions
+
+#TODO as part of process compliance script: consider how logging will be handled - here or process compliance or both? (tee like image regen?)
+# set up logging
+LOGS_DIR=../logs/compliance-trigger
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-compliance-trigger-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec >> ${LOG_FILE} 2>&1
+
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting compliance-trigger"
+
+/usr/java/jdk-8/bin/java -Din=compliance-trigger -cp $CLASSPATH -Dlog4j.configuration=log4j.xml uk.gov.companieshouse.compliance.trigger.ComplianceTrigger compliance-trigger.properties
+if [ $? -gt 0 ]; then
+        f_logError "Non-zero exit code for compliance-trigger java execution"
+        exit 1
+fi
+
+f_logInfo "Ending compliance-trigger"
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/weblogic-batch/compliance-trigger/log4jconfig.xml
+++ b/weblogic-batch/compliance-trigger/log4jconfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <appender name="ConsoleAppender" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%c{1}] %-5p - %m%n"/>
+    </layout>
+  </appender>
+
+  <root>
+    <priority value ="debug" />
+    <appender-ref ref="ConsoleAppender"/>
+  </root>
+
+</log4j:configuration>

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -21,6 +21,10 @@
 ## Check Zombie Officer in chipstab.officer_detail_match
 30 15 * * * $HOME/officer-bulk-process/check--10000-exists.sh 2>&1 >/dev/null
 
+## Compliance Only run on Sat-Sun
+## DONT CHANGE THIS - COMMENT IT OUT IF THERE IS A WEEKEND IR - IT DOESNT HAVE TO RUN
+# 01 00 * * 0,1 $HOME/compliance-trigger/compliance-trigger.sh
+
 ## letter-counts that follow letter-producer
 # 00 06 * * 1 $HOME/letter-producer/bad-letters.sh
 # 15 04 * * 2-6 $HOME/letter-producer/letter-counts.sh


### PR DESCRIPTION
Initial check-in for compliance trigger.
- May require some refactoring when process compliance script added
(marked as TODO).
- Initial local tests have shown it populating COMPLIANCE_STAGE table in
CHIPS with added param -999 to stop any onward processing; will require
fuller tests (including staffware updates) in staging.
- Requires new chips.properties entries:
COMPLIANCE_TRIGGER_DELAY="0"
COMPLIANCE_TRIGGER_IPDETECT="false"
COMPLIANCE_TRIGGER_PAUSE="90"
COMPLIANCE_TRIGGER_EVENTLIMIT="25000"
COMPLIANCE_TRIGGER_CASESATONCE="300"