### PR TITLE
Reference version 1.2.1 of ch-serverjre base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.1
 
 ENV ORACLE_HOME=/apps/oracle \
     ARTIFACTORY_BASE_URL=http://repository.aws.chdev.org:8081/artifactory


### PR DESCRIPTION
This pulls in the addition of the WebLogic CA cert inside the java trust store.  That cert is needed for the CSI JMS utility scripts to use t3s protocol when communicating with WebLogic.

Resolves: https://companieshouse.atlassian.net/browse/CM-1332