### PR TITLE
Add source information to batch email alerts

### DIFF
--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -5,6 +5,8 @@
 #
 #######################################################
 
+LOCATION_STRING="Sent from: ${ENVIRONMENT_LABEL} - ${T3_HOST_FQDN} - EC2 instance ID ${EC2_INSTANCE_ID} (${APP_INSTANCE_NAME})"
+
 ## returns 1 if variable EMAIL_ADDRESS_CSI is unset or a blank string, otherwise 0 
 
 check_email_address_defined_f ()
@@ -36,7 +38,7 @@ patrol_log_alert_chaps_f ()
   if [[ ${LIVE_ENVIRONMENT} == "true" ]]; then
     echo `date`: alert_chaps \> $1  >> /apps/oracle/alertlog/chapspatrol.log
     if check_email_address_defined_f; then
-      echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$1" | msmtp -t
+      echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n${LOCATION_STRING}\n\n$1" | msmtp -t
     fi
   fi
 }
@@ -65,8 +67,8 @@ patrol_log_testharness_f ()
 email_CHAPS_group_f ()
 {
   if check_email_address_defined_f; then
-    echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
-    echo -e "To:${EMAIL_ADDRESS_SERVICE_NOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n${LOCATION_STRING}\n\n$2" | msmtp -t
+    echo -e "To:${EMAIL_ADDRESS_SERVICE_NOW}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Alert: $1\n\n${LOCATION_STRING}\n\n$2" | msmtp -t
   fi
 }
 
@@ -74,6 +76,6 @@ email_CHAPS_group_f ()
 email_report_CHAPS_group_f ()
 {
   if check_email_address_defined_f; then
-     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Report: $1\n\n$2" | msmtp -t
+     echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:CHAPS Report: $1\n\n${LOCATION_STRING}\n\n$2" | msmtp -t
   fi
 }


### PR DESCRIPTION
Adding a line at the start of the body of all emails that identifies their source.