### PR TITLE
Add JMS resubmission scripts and cron entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/ojdbc8/12.2.1.4/ojdbc8-12.2.1.4.jar -o ojdbc8.jar && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/org/jdom/jdom/1.1/jdom-1.1.jar -o jdom.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.1/jmstool-0.0.1.jar -o jmstool.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/libs-release/javax/jms/jms-api/1.1-rev-1/jms-api-1.1-rev-1.jar -o jms-api.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.2/jmstool-0.0.2.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/compliance-trigger/1.1.2/compliance-trigger-1.1.2.jar -o ../compliance-trigger/compliance-trigger.jar && \

--- a/weblogic-batch/admin/jms/README.md
+++ b/weblogic-batch/admin/jms/README.md
@@ -1,0 +1,28 @@
+
+This is the location for various JMS administration scripts that are typically run manually by CSI or are scheduled to run on the cron.
+
+### move-jms.sh
+This is intended to be called by other scripts and not run directly.  It is a wrapper around the Java class that is used to move JMS messages between queues.
+
+
+### reprocess-jms.sh
+
+This is run when there is a need to move JMS messages from one queue to another across a range of WebLogic servers.
+
+The following parameters are required, in this order:
+
+- The name of the queue to move messages from, e.g. uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+- The name of the queue to move messages to, e.g. uk.gov.ch.chips.jms.EfilingRequestQueue
+- The number of messages to move, e.g. 500 
+
+For example:
+./reprocess-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue uk.gov.ch.chips.jms.EfilingRequestQueue 500
+
+The script moves messages on every one of the servers that are listed in environment variables that start with the prefix `JMS_SERVER_`
+
+For example, if the following environment variables were defined, the script would move messages on both these servers:
+
+    JMS_SERVER_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+    JMS_SERVER_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+
+

--- a/weblogic-batch/admin/jms/move-jms.sh
+++ b/weblogic-batch/admin/jms/move-jms.sh
@@ -12,7 +12,7 @@
 #  JMS SERVER URL - the t3 or t3s URL for the WebLogic server, e.g. t3s://1.2.3.4:1234
 #  USERNAME - e.g. weblogic
 #  PASSWORD - e.g. password
-#  NUMBER OF MESSAGES - the number of mesassages to move, e.g. 100
+#  NUMBER OF MESSAGES - the number of messages to move, e.g. 100
 #
 #  This script is intended to be called from another wrapper script and its main
 #  job is to set the CLASSPATH and any Java commandline parameters.
@@ -23,4 +23,3 @@ LIBS=/apps/oracle/libs
 CLASSPATH=${LIBS}/jmstool.jar:${LIBS}/log4j.jar:${LIBS}/jms-api.jar:${LIBS}/wlfullclient.jar:${LIBS}/jdom.jar
 
 /usr/java/jdk-8/bin/java -cp ${CLASSPATH} -Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.MaxMessageSize=100000000 chaps.jms.MoveJMSMessages $*
-

--- a/weblogic-batch/admin/jms/move-jms.sh
+++ b/weblogic-batch/admin/jms/move-jms.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script invokes the Java class chaps.jms.MoveJMSMessages to move JMS 
+#  messages from one queue to another.
+# 
+#  The expected parameters for chaps.jms.MoveJMSMessages are, in order:
+#
+#  JMS SERVER NAME@SOURCE QUEUE - the queue to move messages from, e.g. JMSServer1@uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+#  JMS SERVER NAME@$DESTINATION QUEUE - the queue to move messages to, e.g. JMSServer1@uk.gov.ch.chips.jms.EfilingRequestQueue
+#  JMS SERVER URL - the t3 or t3s URL for the WebLogic server, e.g. t3s://1.2.3.4:1234
+#  USERNAME - e.g. weblogic
+#  PASSWORD - e.g. password
+#  NUMBER OF MESSAGES - the number of mesassages to move, e.g. 100
+#
+#  This script is intended to be called from another wrapper script and its main
+#  job is to set the CLASSPATH and any Java commandline parameters.
+#  
+# =============================================================================
+
+LIBS=/apps/oracle/libs
+CLASSPATH=${LIBS}/jmstool.jar:${LIBS}/log4j.jar:${LIBS}/jms-api.jar:${LIBS}/wlfullclient.jar:${LIBS}/jdom.jar
+
+/usr/java/jdk-8/bin/java -cp ${CLASSPATH} -Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.MaxMessageSize=100000000 chaps.jms.MoveJMSMessages $*
+

--- a/weblogic-batch/admin/jms/reprocess-jms.sh
+++ b/weblogic-batch/admin/jms/reprocess-jms.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script is used to move JMS messages from one queue to another and repeat   
+#  that operation on a number of WebLogic servers.
+# 
+#  This script expects three parameters:
+#
+#  SOURCE QUEUE - the name of the queue to move messages from, e.g. uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+#  DESTINATION QUEUE - the name of the queue to move messages to, e.g. uk.gov.ch.chips.jms.EfilingRequestQueue
+#  NUMBER OF MESSAGES - the number of messages to move, e.g. 500 
+#
+#  In addition to the parameters, it also expects one or more environment
+#  variables that list the connection details for the JMS Servers on which to 
+#  perform the move operation. These variables must be called JMS_SERVER_#
+#  (where # is a unique idetifier such as a number).  E.g.
+#
+#  JMS_SERVER_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_3=t3s://chips-users-rest0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_4=t3s://chips-users-rest1.heritage.aws.internal:21031|JMSServer1
+#
+#  This script is intended to be called directly - either manually or via the cron.
+#  
+# =============================================================================
+
+cd /apps/oracle/admin/jms
+
+# load variables created from setCron script
+source /apps/oracle/env.variables
+
+# set up logging
+LOGS_DIR=../../logs/jms
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-reprocess-jms-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec > >(tee "${LOG_FILE}") 2>&1
+
+if [ "$#" -ne 3 ]
+then
+  f_logError "Invalid number of arguments - expected 3"
+  f_logInfo "Usage: ./reprocess-jms.sh <source queue jndi name> <destination queue jndi name> <number of messages>"
+  f_logInfo "Example: ./reprocess-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue uk.gov.ch.chips.jms.EfilingRequestQueue 500"
+  exit 1
+fi
+
+SOURCE_QUEUE=$1
+DESTINATION_QUEUE=$2
+NUMBER_OF_MESSAGES=$3
+
+JMS_SERVERS=$(env | sort | grep "^JMS_SERVER_")
+for JMS_SERVER in ${JMS_SERVERS};
+do
+  while IFS='|' read -r JMS_SERVER_URL JMS_SERVER_NAME;
+  do
+    f_logInfo "Processing ${JMS_SERVER} moving messages from ${SOURCE_QUEUE} to ${DESTINATION_QUEUE}"
+    ./move-jms.sh ${JMS_SERVER_NAME}@${SOURCE_QUEUE} ${JMS_SERVER_NAME}@${DESTINATION_QUEUE} ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD} ${NUMBER_OF_MESSAGES}
+    if [ $? -gt 0 ]; then
+      f_logError "Non-zero exit code for move-jms execution"
+    fi
+  done < <(echo ${JMS_SERVER##*=})
+done

--- a/weblogic-batch/admin/jms/reprocess-jms.sh
+++ b/weblogic-batch/admin/jms/reprocess-jms.sh
@@ -57,8 +57,5 @@ do
   do
     f_logInfo "Processing ${JMS_SERVER} moving messages from ${SOURCE_QUEUE} to ${DESTINATION_QUEUE}"
     ./move-jms.sh ${JMS_SERVER_NAME}@${SOURCE_QUEUE} ${JMS_SERVER_NAME}@${DESTINATION_QUEUE} ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD} ${NUMBER_OF_MESSAGES}
-    if [ $? -gt 0 ]; then
-      f_logError "Non-zero exit code for move-jms execution"
-    fi
   done < <(echo ${JMS_SERVER##*=})
 done

--- a/weblogic-batch/admin/jms/reprocess-jms.sh
+++ b/weblogic-batch/admin/jms/reprocess-jms.sh
@@ -14,7 +14,7 @@
 #  In addition to the parameters, it also expects one or more environment
 #  variables that list the connection details for the JMS Servers on which to 
 #  perform the move operation. These variables must be called JMS_SERVER_#
-#  (where # is a unique idetifier such as a number).  E.g.
+#  (where # is a unique identifier such as a number).  E.g.
 #
 #  JMS_SERVER_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
 #  JMS_SERVER_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -37,3 +37,11 @@
 ## letter-counts that follow letter-producer
 # 00 06 * * 1 $HOME/letter-producer/bad-letters.sh
 # 15 04 * * 2-6 $HOME/letter-producer/letter-counts.sh
+
+## JMS queue resubmission
+00 5,8,14 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue uk.gov.ch.chips.jms.EfilingRequestQueue 500
+00 7,9,11,13,15,17,19,21,23 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.ImageApiMessageProducerErrorQueue uk.gov.ch.chips.jms.ImageApiMessageProducerQueue 500
+30 06,13,18 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.EfilingImageErrorQueue uk.gov.ch.chips.jms.EfilingImageQueue 500
+00 6,9,12,14,16,18 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.EfilingErrorQueue uk.gov.ch.chips.jms.EfilingQueue 500
+00 23 * * 1-5  $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.FesMessageProducerErrorQueue uk.gov.ch.chips.jms.FesMessageProducerQueue 500
+


### PR DESCRIPTION
Added scripts in /apps/oracle/admin/jms that allow moving of JMS messages from one queue to another.
Added cron entries to run the resubmission of specific queues, from the error queue to the processing queue, as per on-prem crontab.

The main script is reprocess-jms.sh and that takes parameters (see readme or script) that specify the queues to move messages to/from.  The script also needs at least one JMS_SERVER_# environment variable, that determines which server(s) to move the messages on.  This allows for environmental differences and to reprocess messages on several clusters by running one script.

Resolves: https://companieshouse.atlassian.net/browse/CM-1332