### PR TITLE
Filter out unrelated JMS_SERVER_NAME env var

### DIFF
--- a/weblogic-batch/admin/jms/README.md
+++ b/weblogic-batch/admin/jms/README.md
@@ -18,11 +18,11 @@ The following parameters are required, in this order:
 For example:
 ./reprocess-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue uk.gov.ch.chips.jms.EfilingRequestQueue 500
 
-The script moves messages on every one of the servers that are listed in environment variables that start with the prefix `JMS_SERVER_`
+The script moves messages on every one of the servers that are listed in environment variables that start with the prefix `JMS_SERVER_URL_`
 
 For example, if the following environment variables were defined, the script would move messages on both these servers:
 
-    JMS_SERVER_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
-    JMS_SERVER_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+    JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+    JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
 
 

--- a/weblogic-batch/admin/jms/reprocess-jms.sh
+++ b/weblogic-batch/admin/jms/reprocess-jms.sh
@@ -30,6 +30,9 @@ cd /apps/oracle/admin/jms
 # load variables created from setCron script
 source /apps/oracle/env.variables
 
+# remove unrelated JMS_SERVER_NAME env var
+unset JMS_SERVER_NAME
+
 # set up logging
 LOGS_DIR=../../logs/jms
 mkdir -p ${LOGS_DIR}

--- a/weblogic-batch/admin/jms/reprocess-jms.sh
+++ b/weblogic-batch/admin/jms/reprocess-jms.sh
@@ -13,13 +13,13 @@
 #
 #  In addition to the parameters, it also expects one or more environment
 #  variables that list the connection details for the JMS Servers on which to 
-#  perform the move operation. These variables must be called JMS_SERVER_#
+#  perform the move operation. These variables must be called JMS_SERVER_URL_#
 #  (where # is a unique idetifier such as a number).  E.g.
 #
-#  JMS_SERVER_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
-#  JMS_SERVER_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
-#  JMS_SERVER_3=t3s://chips-users-rest0.heritage.aws.internal:21031|JMSServer1
-#  JMS_SERVER_4=t3s://chips-users-rest1.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_3=t3s://chips-users-rest0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_4=t3s://chips-users-rest1.heritage.aws.internal:21031|JMSServer1
 #
 #  This script is intended to be called directly - either manually or via the cron.
 #  
@@ -29,9 +29,6 @@ cd /apps/oracle/admin/jms
 
 # load variables created from setCron script
 source /apps/oracle/env.variables
-
-# remove unrelated JMS_SERVER_NAME env var
-unset JMS_SERVER_NAME
 
 # set up logging
 LOGS_DIR=../../logs/jms
@@ -53,7 +50,7 @@ SOURCE_QUEUE=$1
 DESTINATION_QUEUE=$2
 NUMBER_OF_MESSAGES=$3
 
-JMS_SERVERS=$(env | sort | grep "^JMS_SERVER_")
+JMS_SERVERS=$(env | sort | grep "^JMS_SERVER_URL_")
 for JMS_SERVER in ${JMS_SERVERS};
 do
   while IFS='|' read -r JMS_SERVER_URL JMS_SERVER_NAME;


### PR DESCRIPTION
The resubmission script was looking for any environment variables that start with `JMS_SERVER_` but there is an existing var `JMS_SERVER_NAME` that was being picked up and shouldn't be.

This updates the script to change the vars that are used to be `JMS_SERVER_URL_*` instead

Resolves: https://companieshouse.atlassian.net/browse/CM-1332