### PR TITLE
Add scripts to email a report of docs stuck in the EF queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yum -y install gettext && \
     yum -y install oracle-instantclient-sqlplus && \
     yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y install msmtp && \
+    yum -y install xmlstarlet && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/weblogic-batch/admin/jms/README.md
+++ b/weblogic-batch/admin/jms/README.md
@@ -1,10 +1,37 @@
 
 This is the location for various JMS administration scripts that are typically run manually by CSI or are scheduled to run on the cron.
 
-### move-jms.sh
-This is intended to be called by other scripts and not run directly.  It is a wrapper around the Java class that is used to move JMS messages between queues.
+### list-all-jms.sh
+This is run when there is a need to list JMS messages held within one queue across a range of WebLogic servers.
+
+The following parameter is required:
+
+- The name of the queue to list messages in, e.g. uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+
+For example:
+./list-all-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+
+The script list messages on every one of the servers that are listed in environment variables that start with the prefix `JMS_SERVER_URL_`
+
+For example, if the following environment variables were defined, the script would list messages on both these servers:
+
+    JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+    JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
 
 
+### report-stuck-ef-submissions.sh
+
+This is run in order to email a report of "stuck" JMS messages in the EfilingRequestErrorQueue across all WebLogic servers.
+
+No parameters are required.
+
+For example:
+./report-stuck-ef-submissions.sh
+
+The script makes use of list-all-jms.sh and processes the output from that to generate a report that is then emailed to the address 
+held in the environment variable `EMAIL_ADDRESS_CSI`.
+
+    
 ### reprocess-jms.sh
 
 This is run when there is a need to move JMS messages from one queue to another across a range of WebLogic servers.
@@ -24,5 +51,12 @@ For example, if the following environment variables were defined, the script wou
 
     JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
     JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+
+    
+### list-jms.sh
+This is intended to be called by other scripts and not run directly.  It is a wrapper around the Java class that is used to list JMS messages within a queue.
+
+### move-jms.sh
+This is intended to be called by other scripts and not run directly.  It is a wrapper around the Java class that is used to move JMS messages between queues.
 
 

--- a/weblogic-batch/admin/jms/list-all-jms.sh
+++ b/weblogic-batch/admin/jms/list-all-jms.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script is used to list JMS messages in a specific queue and repeat   
+#  that operation on a number of WebLogic servers.
+# 
+#  This script expects one parameter:
+#
+#  QUEUE - the name of the queue to list JMS messages in, e.g. uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+#
+#  In addition to the parameters, it also expects one or more environment
+#  variables that list the connection details for the JMS Servers on which to 
+#  perform the list operation. These variables must be called JMS_SERVER_URL_#
+#  (where # is a unique identifier such as a number).  E.g.
+#
+#  JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_3=t3s://chips-users-rest0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_4=t3s://chips-users-rest1.heritage.aws.internal:21031|JMSServer1
+#
+# =============================================================================
+
+cd /apps/oracle/admin/jms
+
+# load variables created from setCron script
+source /apps/oracle/env.variables
+
+# set up logging
+LOGS_DIR=../../logs/jms
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-list-all-jms-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec > >(tee "${LOG_FILE}") 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  f_logError "Invalid number of arguments - expected 1"
+  f_logInfo "Usage: ./list-all-jms.sh <queue jndi name>"
+  f_logInfo "Example: ./list-all-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue"
+  exit 1
+fi
+
+QUEUE=$1
+
+JMS_SERVERS=$(env | sort | grep "^JMS_SERVER_URL_")
+for JMS_SERVER in ${JMS_SERVERS};
+do
+  while IFS='|' read -r JMS_SERVER_URL JMS_SERVER_NAME;
+  do
+    f_logInfo "Processing ${JMS_SERVER} listing messages in ${QUEUE}"
+    ./list-jms.sh ${JMS_SERVER_NAME}@${QUEUE} ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD}
+  done < <(echo ${JMS_SERVER##*=})
+done

--- a/weblogic-batch/admin/jms/list-jms.sh
+++ b/weblogic-batch/admin/jms/list-jms.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script invokes the Java class chaps.jms.ListJMSMessages to list JMS 
+#  messages held in a queue.
+# 
+#  The expected parameters for chaps.jms.ListJMSMessages are, in order:
+#
+#  JMS SERVER NAME@QUEUE - the queue to list messages in, e.g. JMSServer1@uk.gov.ch.chips.jms.EfilingRequestErrorQueue
+#  JMS SERVER URL - the t3 or t3s URL for the WebLogic server, e.g. t3s://1.2.3.4:1234
+#  USERNAME - e.g. weblogic
+#  PASSWORD - e.g. password
+#
+#  This script is intended to be called from another wrapper script and its main
+#  job is to set the CLASSPATH and any Java commandline parameters.
+#  
+# =============================================================================
+
+LIBS=/apps/oracle/libs
+CLASSPATH=${LIBS}/jmstool.jar:${LIBS}/log4j.jar:${LIBS}/jms-api.jar:${LIBS}/wlfullclient.jar:${LIBS}/jdom.jar
+
+/usr/java/jdk-8/bin/java -cp ${CLASSPATH} -Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.MaxMessageSize=100000000 chaps.jms.ListJMSMessages $*

--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script is used to report on JMS messages in the EfilingRequestErrorQueue    
+#  across all WebLogic servers.
+#
+# =============================================================================
+
+parseXML() {
+  BARCODE=$(xmlstarlet sel -t -v "//barcode" $1)
+  FORM_TYPE=$(xmlstarlet sel -t -v "//form/@type" $1)
+  CORPORATE_BODY_NAME=$(xmlstarlet sel -t -v "//corporateBodyName" $1)
+  INCORPORATION_NUMBER=$(xmlstarlet sel -t -v "//incorporationNumber" $1)
+  METHOD=$(xmlstarlet sel -t -v "//method" $1)
+}
+
+parseAndWriteMetaData () {
+  parseXML $1
+  echo "${FORM_TYPE}|${BARCODE}|${INCORPORATION_NUMBER}|${METHOD}|${CORPORATE_BODY_NAME}" >> $2
+  rm -f $1
+}
+
+smallBanner() {
+ DASHES="------------------------------------------------------------------------------------"
+ echo
+ echo ${DASHES}
+ echo $1
+ echo ${DASHES}
+ echo
+}
+
+cd /apps/oracle/admin/jms
+
+# load variables created from setCron script
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst <../../.msmtprc.template >../../.msmtprc
+
+# set up logging
+LOGS_DIR=../../logs/jms
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-report-stuck-ef-submissions-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec > >(tee "${LOG_FILE}") 2>&1
+
+TMP_LIST_FILE=list-all-jms.output
+TMP_METADATA_FILE=extracted-metadata.tmp
+TMP_XML_FILE=xml.tmp
+
+# Extract a list of submission xml from all jms servers
+./list-all-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue > ${TMP_LIST_FILE}
+
+# Tidy up the extracted list so that it just contains xml
+sed -i -n '/^<?xml/,/<\/form>/p' ${TMP_LIST_FILE}
+
+# Check if there is any xml in TMP_LIST_FILE - if not then we can exit as no stuck docs
+grep -q xml ${TMP_LIST_FILE}
+if [[ $? -gt 0 ]]
+then
+  echo "No stuck documents"
+  exit 0
+fi
+
+# Extract data from the list of stuck docs in TMP_LIST_FILE, one document at a time
+rm -f ${TMP_XML_FILE} ${TMP_METADATA_FILE}
+while read -r LINE; do
+  if [[ ${LINE} =~ ^\<\?xml ]]
+  then
+    # new xml found - process previously saved xml if present
+    if [[ -f ${TMP_XML_FILE} ]]
+    then
+      parseAndWriteMetaData ${TMP_XML_FILE} ${TMP_METADATA_FILE}
+    fi
+  fi
+  echo "${LINE}" >> ${TMP_XML_FILE}
+
+done <${TMP_LIST_FILE}
+# Process the last submission as we have reached the end of TMP_LIST_FILE
+parseAndWriteMetaData ${TMP_XML_FILE} ${TMP_METADATA_FILE}
+
+# Now we have our metadata, we need to generate a report
+
+TMP_REPORT_FILE=report.tmp
+rm -f  ${TMP_REPORT_FILE}
+
+COUNT=$(grep -c -v scan ${TMP_METADATA_FILE})
+if [[ ${COUNT} -gt 0 ]]
+then
+  { 
+  smallBanner "EF/CHS docs"
+
+  echo "  Cnt | Type"
+  grep -v scan ${TMP_METADATA_FILE} | sort | awk -F\| '{print $1}' | uniq -c
+
+  echo
+  IFS=$'\n'
+  for DOC_TYPE in $(grep -v scan ${TMP_METADATA_FILE} | sort | awk -F\| '{print $1}' | uniq)
+  do
+    echo "  ${DOC_TYPE}:"
+    grep -v scan ${TMP_METADATA_FILE} | grep -E "^${DOC_TYPE}" | sed 's/[^|]*|\(.*\)/  \1/' | sed 's/|/    /g'
+    echo
+  done
+  } >> ${TMP_REPORT_FILE}
+fi
+
+
+COUNT=$(grep -c scan ${TMP_METADATA_FILE})
+if [[ ${COUNT} -gt 0 ]]
+then
+  {
+  smallBanner "FES/Scanned docs"
+
+  echo "  Cnt | Type"
+  grep scan ${TMP_METADATA_FILE} | sort | awk -F\| '{print $1}' | uniq -c
+
+  echo
+  IFS=$'\n'
+  for DOC_TYPE in $(grep scan ${TMP_METADATA_FILE} | sort | awk -F\| '{print $1}' | uniq)
+  do
+    echo "  ${DOC_TYPE}:"
+    grep scan ${TMP_METADATA_FILE} | grep -E "^${DOC_TYPE}" | sed 's/[^|]*|\(.*\)/  \1/' | sed 's/|/    /g'
+    echo
+  done
+  } >> ${TMP_REPORT_FILE}
+fi
+
+# Now we need to email out the report
+
+LOCATION_STRING="Sent from: ${ENVIRONMENT_LABEL} - ${T3_HOST_FQDN} - EC2 instance ID ${EC2_INSTANCE_ID} (${APP_INSTANCE_NAME})"
+DATE=$(date)
+SUBJECT="Following CLOUD EF or FES/Scanned docs currently stuck ${DATE}"
+HEADING="Snapshot of docs in EfilingRequestErrorQueue at ${DATE}. CSI will fix these and push these to QH queues ASAP."
+
+TMP_EMAIL_FILE=email.tmp
+echo -e "To:${EMAIL_ADDRESS_CSI}\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:${SUBJECT}\n\n${LOCATION_STRING}\n\n${HEADING}" > ${TMP_EMAIL_FILE}
+cat ${TMP_REPORT_FILE} >> ${TMP_EMAIL_FILE}
+cat ${TMP_EMAIL_FILE} | msmtp -t
+
+# Clean up
+rm -f ${TMP_EMAIL_FILE}
+rm -f ${TMP_REPORT_FILE}
+

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -45,3 +45,6 @@
 00 6,9,12,14,16,18 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.EfilingErrorQueue uk.gov.ch.chips.jms.EfilingQueue 500
 00 23 * * 1-5  $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.FesMessageProducerErrorQueue uk.gov.ch.chips.jms.FesMessageProducerQueue 500
 
+## JMS queue monitoring
+05 9,15 * * 1,2,3,4,5 $HOME/admin/jms/report-stuck-ef-submissions.sh
+


### PR DESCRIPTION
This adds scripts to list JMS messages that are held in the EfilingRequestErrorQueue on CHIPS, and to email a report to the CSI email address.

Resolves: https://companieshouse.atlassian.net/browse/CM-1330