### PR TITLE
Allow override of email address for stuck docs report

### DIFF
--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -4,10 +4,14 @@
 #
 #  This script is used to report on JMS messages in the EfilingRequestErrorQueue    
 #  across all WebLogic servers.
+#
+#  An optional parameter may be supplied which sets the email address(es) to send
+#  the report to.  This should be a comma separated list of email recipients without spaces.
 # 
-#  The script uses an optional STUCK_DOCS_REPORT_EMAIL_ADDRESSES environment variable
-#  to determine which email addresses to send the report to.  This should be a comma
-#  separated list of email recipients with no spaces.
+#  If no parameter is supplied, the script uses an optional STUCK_DOCS_REPORT_EMAIL_ADDRESSES
+#  environment variable to determine which email addresses to send the report to.
+#  This should be a comma separated list of email recipients without spaces.
+#
 #  If the STUCK_DOCS_REPORT_EMAIL_ADDRESSES environment variable is not set, the report
 #  will be sent to just the email address in the EMAIL_ADDRESS_CSI environment variable.
 #
@@ -139,11 +143,11 @@ then
 fi
 
 # Now we need to email out the report
+STUCK_DOCS_REPORT_EMAIL_ADDRESSES=${1:-${STUCK_DOCS_REPORT_EMAIL_ADDRESSES}}
 EMAIL_ADDRESSES=${STUCK_DOCS_REPORT_EMAIL_ADDRESSES:-${EMAIL_ADDRESS_CSI}}
 email_report_f ${EMAIL_ADDRESSES} "Following CLOUD EF or FES/Scanned docs currently stuck ${DATE}" "$(cat ${TMP_REPORT_FILE})"
 
 # Clean up
 rm -f ${TMP_EMAIL_FILE}
 rm -f ${TMP_REPORT_FILE}
-
 

--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -46,5 +46,8 @@
 00 23 * * 1-5  $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.FesMessageProducerErrorQueue uk.gov.ch.chips.jms.FesMessageProducerQueue 500
 
 ## JMS queue monitoring
-05 9,15 * * 1,2,3,4,5 $HOME/admin/jms/report-stuck-ef-submissions.sh
+# Send report to csi and servicenow (emails in STUCK_DOCS_REPORT_EMAIL_ADDRESSES env var)
+05 9 * * 1,2,3,4,5 $HOME/admin/jms/report-stuck-ef-submissions.sh
+# Send report to just csi
+05 15 * * 1,2,3,4,5 source $HOME/env.variables; /apps/oracle/admin/jms/report-stuck-ef-submissions.sh ${EMAIL_ADDRESS_CSI}
 

--- a/weblogic-batch/scripts/alert_functions
+++ b/weblogic-batch/scripts/alert_functions
@@ -93,6 +93,6 @@ email_report_CHAPS_group_f ()
 email_report_f ()
 {
   if check_email_address_defined_f; then
-     echo -e "To:$1\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:$2\n\n${LOCATION_STRING}\n\n$3" | msmtp -t
+     echo -e "To:$1\nFrom:${EMAIL_ADDRESS_CSI}\nSubject:$2\n\n${LOCATION_STRING}\n\n$3\n\n" | msmtp -t
   fi
 }


### PR DESCRIPTION
Email report for stuck docs to csi & servicenow in the mornings, and override to just send to csi in the afternoons.

Resolves: https://companieshouse.atlassian.net/browse/CM-1330