### PR TITLE
CM-1099 adding dissolution-certificate-producer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/compliance-trigger/1.1.2/compliance-trigger-1.1.2.jar -o ../compliance-trigger/compliance-trigger.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/dissolution-certificate-producer/1.0.0-rc2/dissolution-certificate-producer-1.0.0-rc2.jar -o ../dissolution-certificate-producer/dissolution-certificate-producer.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/doc1-producer/1.8.1/doc1-producer-1.8.1.jar -o ../doc1-producer/doc1-producer.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/image-regeneration/1.2.5/image-regeneration-1.2.5.jar -o ../image-regeneration/image-regeneration.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/letter-producer/1.1.1/letter-producer-1.1.1.jar -o ../letter-producer/letter-producer.jar && \

--- a/weblogic-batch/dissolution-certificate-producer/dissolution-certificate-producer.properties.template
+++ b/weblogic-batch/dissolution-certificate-producer/dissolution-certificate-producer.properties.template
@@ -1,0 +1,4 @@
+dissolutionCertsProducer.provider.url=${JMS_JNDIPROVIDERURL}
+dissolutionCertsProducer.security.principal=${WEBLOGIC_ADMIN_USERNAME}
+dissolutionCertsProducer.security.credentials=${ADMIN_PASSWORD}
+dissolutionCertsProducer.defaultBatchSize=100

--- a/weblogic-batch/dissolution-certificate-producer/dissolution-certificate-producer.sh
+++ b/weblogic-batch/dissolution-certificate-producer/dissolution-certificate-producer.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+##  This script will fire all XML files in the defined directory in turn to the DissolutionCertificate JMS queue
+##  Its primary use is as a bulk test harness for dissolution certificate production. However, it is also useful
+##  for reprocessing a list of XML files that may have failed or need new images for whatever reason.
+
+##  dissolution-certificate-producer.sh: Shell wrapper to run the dissolution-certificate-producer.jar file
+##  Options are -d <directory path> (required) -f <file name> (optional)
+
+cd /apps/oracle/dissolution-certificate-producer
+
+# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# create properties file and substitutes values
+envsubst <dissolution-certificate-producer.properties.template >dissolution-certificate-producer.properties
+
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/wlfullclient.jar:/apps/oracle/libs/log4j.jar:/apps/oracle/libs/jdom.jar:/apps/oracle/dissolution-certificate-producer/dissolution-certificate-producer.jar
+
+# set up logging
+LOGS_DIR=../logs/dissolution-certificate-producer
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-dissolution-certificate-producer-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+OPTS_TEXT="Options are -d <directory path> (required) -f <file name> (optional)"
+
+while getopts :d:f: flag
+do
+  case "${flag}" in
+    d) INDIR=${OPTARG};;
+    f) INFILE=${OPTARG};;
+    *) echo "Failed to start dissolution-certificate-producer: Unknown parameter value. ${OPTS_TEXT}";
+       exit 1;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+if [[ $# > 0 ]]; then
+        echo "Failed to start dissolution-certificate-producer: Unexpected parameter(s) $@. ${OPTS_TEXT}"
+        exit 1
+fi
+if [[ ! -d ${INDIR} ]]; then
+    echo "Failed to start dissolution-certificate-producer: ${INDIR} is not a directory. ${OPTS_TEXT}";
+    exit 1
+fi
+
+echo "Check ${LOG_FILE} for log output."
+
+exec >>${LOG_FILE} 2>&1
+
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting dissolution-certificate-producer"
+f_logInfo "Input directory path: $INDIR (filename, if given: $INFILE)"
+
+/usr/java/jdk-8/bin/java -Din=dissolution-certificate-producer -cp $CLASSPATH uk.gov.companieshouse.dissolutioncerts.DissolutionCertsProducerRunner dissolution-certificate-producer.properties $INDIR $INFILE
+
+if [ $? -gt 0 ]; then
+    f_logError "Non-zero exit code for dissolution-certificate-producer java execution"
+    exit 1
+fi
+
+f_logInfo "Ending dissolution-certificate-producer"
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/weblogic-batch/process-compliance/process-ch-address-files.sh
+++ b/weblogic-batch/process-compliance/process-ch-address-files.sh
@@ -87,7 +87,7 @@ if [ -d "${DOC1FILE_CH_ADDRESS_DIR}" ]; then
 
   # DOC1FILE_CH_ADDRESS_DIR is docker mount dir so can't move - moving contents instead
   DATED_DIR=${DOC1FILE_CH_ADDRESS_DIR_ARCHIVE}/$(basename ${DOC1FILE_CH_ADDRESS_DIR}).$(date +'%Y-%m-%d_%H-%M-%S')
-  echo "Moving ${DOC1FILE_CH_ADDRESS_DIR} contents to ${DATED_DIR}"
+  f_logInfo "Moving ${DOC1FILE_CH_ADDRESS_DIR} contents to ${DATED_DIR}"
   mkdir ${DATED_DIR}
   mv ${DOC1FILE_CH_ADDRESS_DIR}/* ${DATED_DIR}/
 


### PR DESCRIPTION
First pass at adding dissolution-certificate-producer files

Script has been amended to take parameters to remove the need to edit
the script manually before running.
Options are -d <directory path> (required) -f <file name> (optional)

(Also committing a typo fix to clean up logging in
process-ch-address-files.sh)