### PR TITLE
CM-1104 script changes after recent live issues

### DIFF
--- a/weblogic-batch/cron/crontab.txt
+++ b/weblogic-batch/cron/crontab.txt
@@ -31,9 +31,8 @@
 # Send the files containing the CH Default Address through doc1 so that they end up in Smartview
 # 00 14 * * 2-6 $HOME/process-compliance/process-ch-address-files.sh
 
-## letter-counts that follow letter-producer
+## weekly bad-letters report
 # 00 06 * * 1 $HOME/letter-producer/bad-letters.sh
-# 15 04 * * 2-6 $HOME/letter-producer/letter-counts.sh
 
 ## JMS queue resubmission
 00 5,8,14 * * * $HOME/admin/jms/reprocess-jms.sh uk.gov.ch.chips.jms.EfilingRequestErrorQueue uk.gov.ch.chips.jms.EfilingRequestQueue 500
@@ -47,4 +46,3 @@
 05 9 * * 1,2,3,4,5 $HOME/admin/jms/report-stuck-ef-submissions.sh
 # Send report to just csi
 05 15 * * 1,2,3,4,5 source $HOME/env.variables; /apps/oracle/admin/jms/report-stuck-ef-submissions.sh ${EMAIL_ADDRESS_CSI}
-

--- a/weblogic-batch/letter-producer/letter-counts.sh
+++ b/weblogic-batch/letter-producer/letter-counts.sh
@@ -17,7 +17,8 @@ mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-letter-counts-$(date +'%Y-%m-%d_%H-%M-%S').log"
 source /apps/oracle/scripts/logging_functions
 
-exec >> ${LOG_FILE} 2>&1
+# Use tee to direct output to log file while also keeping it available to calling script
+exec > >(tee "${LOG_FILE}") 2>&1
 
 DOC1_GATEWAY_LOCATION_EW="/apps/oracle/input-output/gateway/doc1/ew"
 DOC1_PRODUCER_OUTPUT_LOCATION="/apps/oracle/input-output/doc1ProducerOutput"


### PR DESCRIPTION
- call letter-counts.sh script from process-compliance.sh script instead
of from cron so that it is sent as soon as the files are available
- retry after a one minute sleep when a write to the gateway fails, and
notify CSI via an email if the 2nd attempt fails