### PR TITLE
CM-1415 derive property CHIPS_SQLPLUS_CONN_STRING

### DIFF
--- a/weblogic-batch/setCron.sh
+++ b/weblogic-batch/setCron.sh
@@ -3,6 +3,11 @@
 # sed command to add export to beginning of each line and quote values
 env | sed 's/^/export /;s/=/&"/;s/$/"/' > /apps/oracle/env.variables
 
+# append derived variable CHIPS_SQLPLUS_CONN_STRING to properties file
+CHIPS_SQLPLUS_CREDS=${DB_USER_CHIPSDS}/${DB_PASSWORD_CHIPSDS}
+CHIPS_SQLPLUS_PATH=$(echo ${DB_URL_CHIPSDS} | awk -F'@' '{print $2}' |  awk -F':' '{print $1 ":" $2 "/" $3}')
+echo "export CHIPS_SQLPLUS_CONN_STRING=\"${CHIPS_SQLPLUS_CREDS}@${CHIPS_SQLPLUS_PATH}\"" >> /apps/oracle/env.variables
+
 # set weblogic user crontab
 su -c 'crontab /apps/oracle/cron/crontab.txt' weblogic
 


### PR DESCRIPTION
Constructing property CHIPS_SQLPLUS_CONN_STRING from existing props
rather than using a separate property that has to be kept in synch.

Appending to env.variables file as part of setCron.sh setup so that
existing scripts can use it unchanged.