### PR TITLE
Remove attachment elements instead of data elements

### DIFF
--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -68,7 +68,7 @@ TMP_XML_FILE=xml.tmp
 
 # Tidy up the extracted list so that it just contains xml without any attachment data
 sed -i -n '/^<?xml/,/<\/form>/p' ${TMP_LIST_FILE}
-sed -i '/<data>/,/<\/data>/d' ${TMP_LIST_FILE}
+sed -i '/<attachment>/,/<\/attachment>/d' ${TMP_LIST_FILE}
 
 # Check if there is any xml in TMP_LIST_FILE - if not then we can exit as no stuck docs
 grep -q xml ${TMP_LIST_FILE}


### PR DESCRIPTION
Some email reports, generated by `weblogic-batch/admin/jms/report-stuck-ef-submissions.sh`, were missing docs due to the `<data>` elements being on one long line, which was causing an intermediate output file to be truncated when we tried to remove them with sed.  
This change removes the parent `<attachment>` elements instead of `<data>` elements, which seems to fix the issue.