### PR TITLE
Report stuck JMS messages in ChipsGenericErrorQueue

### DIFF
--- a/weblogic-batch/admin/jms/README.md
+++ b/weblogic-batch/admin/jms/README.md
@@ -31,6 +31,18 @@ For example:
 The script makes use of list-all-jms.sh and processes the output from that to generate a report that is then emailed to the address 
 held in the environment variable `EMAIL_ADDRESS_CSI`.
 
+
+### report-stuck-chips-generic-messages.sh
+
+This is run in order to email a report of "stuck" JMS messages in the ChipsGenericErrorQueue across all WebLogic servers.
+
+No parameters are required.
+
+For example:
+./report-stuck-chips-generic-messages.sh
+
+The script makes use of list-all-jms.sh and processes the output from that to generate a report that is then emailed to the address 
+held in the environment variable `EMAIL_ADDRESS_CSI`.
     
 ### reprocess-jms.sh
 

--- a/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
+++ b/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
@@ -82,7 +82,7 @@ done
 LINE_COUNT=$(wc -l ${TMP_REPORT_FILE} | awk '{print $1}')
 if [[ ${LINE_COUNT} -eq 0 ]]
 then
-  echo "No stuck messages"
+  f_logInfo "No stuck messages"
   exit 0
 fi
 

--- a/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
+++ b/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
@@ -27,7 +27,7 @@ reportStuckTextMessages() {
   if [[ ${EXIT_CODE} -eq 0 ]]
   then
 
-    smallBanner "Stuck ${MESSAGE_TYPE} messages"
+    smallBanner "Stuck ${MESSAGE_TYPE} messages - ($(grep -r ${MESSAGE_TYPE} ${TMP_DIR} | wc -l) of these)"
 
     for FILE in $FILES_WITH_MESSAGES
     do
@@ -70,13 +70,13 @@ mkdir -p ${TMP_DIR}
 awk -v var="${TMP_DIR}/" '/JMS_SERVER/{close(out);out=var "jms" ++i} {print > out}' ${TMP_LIST_FILE}
 
 # Now create a report file
-TMP_REPORT_FILE=report-chips-generic.tmp
-DATE=$(date)
-
 # Check for each message type in turn and add to the report file
+TMP_REPORT_FILE=report-chips-generic.tmp
 
-# EXTENSIONS_CONTACT messages
-reportStuckTextMessages EXTENSIONS_CONTACT "${TMP_DIR}" >> ${TMP_REPORT_FILE}
+for MESSAGE_TYPE in EXTENSIONS_CONTACT HMRC_BULK_OBJECTIONS LFP_APPEAL_CONTACT PSC_DISCREPANCIES WEB_PSC_DISCREPANCIES PROMISE_TO_FILE OCR_RESPONSE OBJECTION_TO_STRIKE_OFF ORDINARY_BULK_OBJECTIONS
+do
+  reportStuckTextMessages ${MESSAGE_TYPE} "${TMP_DIR}" >> ${TMP_REPORT_FILE}
+done
 
 # Count lines in the report file to see if we need to send an alert
 LINE_COUNT=$(wc -l ${TMP_REPORT_FILE} | awk '{print $1}')
@@ -87,7 +87,7 @@ then
 fi
 
 # Now we need to email out the report
-email_report_f ${EMAIL_ADDRESS_CSI} "Following JMS messages are stuck in ChipsGenericErrorQueue ${DATE}" "$(cat ${TMP_REPORT_FILE})"
+email_report_f ${EMAIL_ADDRESS_CSI} "Following JMS messages are stuck in ChipsGenericErrorQueue $(date)" "$(cat ${TMP_REPORT_FILE})"
 
 # Clean up
 rm -f ${TMP_EMAIL_FILE}

--- a/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
+++ b/weblogic-batch/admin/jms/report-stuck-chips-generic-messages.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script is used to report on JMS messages in the ChipsGenericErrorQueue    
+#  across all WebLogic servers.
+#
+# =============================================================================
+
+
+smallBanner() {
+ DASHES="------------------------------------------------------------------------------------"
+ echo
+ echo ${DASHES}
+ echo $1
+ echo ${DASHES}
+ echo
+}
+
+reportStuckTextMessages() {
+  MESSAGE_TYPE=$1
+  TMP_DIR=$2
+
+  FILES_WITH_MESSAGES=$(grep -lr ${MESSAGE_TYPE} ${TMP_DIR})
+  EXIT_CODE=$?
+
+  if [[ ${EXIT_CODE} -eq 0 ]]
+  then
+
+    smallBanner "Stuck ${MESSAGE_TYPE} messages"
+
+    for FILE in $FILES_WITH_MESSAGES
+    do
+      echo
+      JMS_SERVER=$(head -1 ${FILE} | sed 's/.*\(chips-.*\):.*|\(JMSServer[0-9]*\).*/\1 \2/g')
+      echo ":- ${JMS_SERVER}"
+      echo
+      grep ${MESSAGE_TYPE} $FILE | awk '{print $0,"\n"}'
+      echo
+    done
+  fi
+}
+
+cd /apps/oracle/admin/jms
+
+# load variables created from setCron script
+KEEP_HOME=${HOME}
+source /apps/oracle/env.variables
+HOME=${KEEP_HOME}
+
+# Set up mail config for msmtp & load alerting functions
+envsubst <../../.msmtprc.template >../../.msmtprc
+source ../../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../../logs/jms
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-report-stuck-chips-generic-messages-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec > >(tee "${LOG_FILE}") 2>&1
+
+# Extract a list of submission xml from all jms servers
+TMP_LIST_FILE=list-all-jms-chips-generic.output
+./list-all-jms.sh uk.gov.ch.chips.jms.ChipsGenericErrorQueue > ${TMP_LIST_FILE}
+
+# Split the list of stuck JMS messagest into individual files - one file for each JMS_SERVER
+TMP_DIR=chips-generic.tmp
+mkdir -p ${TMP_DIR}
+awk -v var="${TMP_DIR}/" '/JMS_SERVER/{close(out);out=var "jms" ++i} {print > out}' ${TMP_LIST_FILE}
+
+# Now create a report file
+TMP_REPORT_FILE=report-chips-generic.tmp
+DATE=$(date)
+
+# Check for each message type in turn and add to the report file
+
+# EXTENSIONS_CONTACT messages
+reportStuckTextMessages EXTENSIONS_CONTACT "${TMP_DIR}" >> ${TMP_REPORT_FILE}
+
+# Count lines in the report file to see if we need to send an alert
+LINE_COUNT=$(wc -l ${TMP_REPORT_FILE} | awk '{print $1}')
+if [[ ${LINE_COUNT} -eq 0 ]]
+then
+  echo "No stuck messages"
+  exit 0
+fi
+
+# Now we need to email out the report
+email_report_f ${EMAIL_ADDRESS_CSI} "Following JMS messages are stuck in ChipsGenericErrorQueue ${DATE}" "$(cat ${TMP_REPORT_FILE})"
+
+# Clean up
+rm -f ${TMP_EMAIL_FILE}
+rm -f ${TMP_REPORT_FILE}
+rm -f ${TMP_LIST_FILE}
+rm -rf ${TMP_DIR}

--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -74,7 +74,7 @@ sed -i '/<attachment>/,/<\/attachment>/d' ${TMP_LIST_FILE}
 grep -q xml ${TMP_LIST_FILE}
 if [[ $? -gt 0 ]]
 then
-  echo "No stuck documents"
+  f_logInfo "No stuck documents"
   exit 0
 fi
 


### PR DESCRIPTION
Adds a new script, `report-stuck-chips-generic-messages.sh`, that emails out a list of any JMS messages that are stuck in the ChipsGenericErrorQueue.

Resolves: https://companieshouse.atlassian.net/browse/CM-1454