### PR TITLE
CM-1467 move crontab check script

### DIFF
--- a/weblogic-batch/scripts/track-crontab-changes.sh
+++ b/weblogic-batch/scripts/track-crontab-changes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd /apps/oracle/cron
+cd /apps/oracle/scripts
 
 # load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
 KEEP_HOME=${HOME}


### PR DESCRIPTION
Moving script out of cron dir as this is overwritten by docker mount so that crontab can be sourced from S3.
Using scripts dir as this is one that could be useful in other batch containers, like others in that dir.