### PR TITLE
Formatting fix for EF stuck docs report

### DIFF
--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -20,7 +20,7 @@
 parseXML() {
   BARCODE=$(xmlstarlet sel -t -v "//barcode" $1)
   FORM_TYPE=$(xmlstarlet sel -t -v "//form/@type" $1)
-  CORPORATE_BODY_NAME=$(xmlstarlet sel -t -v "//corporateBodyName" $1)
+  CORPORATE_BODY_NAME=$(xmlstarlet sel -t -v "//corporateBodyName[1]" $1)
   INCORPORATION_NUMBER=$(xmlstarlet sel -t -v "//incorporationNumber" $1)
   METHOD=$(xmlstarlet sel -t -v "//method" $1)
 }


### PR DESCRIPTION
OE01 submissions from CHS seem to have two `corporateBodyName` elements, which was messing up the formatting of the stuck EF docs report.  The script `weblogic-batch/admin/jms/report-stuck-ef-submissions.sh` has been altered to just extract the first `corporateBodyName`.
