### PR TITLE
Fix for live issue seen with report-stuck-ef-submissions.sh  

### DIFF
--- a/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
+++ b/weblogic-batch/admin/jms/report-stuck-ef-submissions.sh
@@ -68,6 +68,7 @@ TMP_XML_FILE=xml.tmp
 
 # Tidy up the extracted list so that it just contains xml without any attachment data
 sed -i -n '/^<?xml/,/<\/form>/p' ${TMP_LIST_FILE}
+sed -i 's/<attachment>.*<\/attachment>//g' ${TMP_LIST_FILE}
 sed -i '/<attachment>/,/<\/attachment>/d' ${TMP_LIST_FILE}
 
 # Check if there is any xml in TMP_LIST_FILE - if not then we can exit as no stuck docs


### PR DESCRIPTION
Handle case where there are no linefeeds in the xml between the `<attachment>` elements, which 
was causing the report to be garbled.