### PR TITLE
Improve handling of stuck EF JMS response messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/virtual-release/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.jar -o javax.ws.rs-api.jar && \ 
     curl ${ARTIFACTORY_BASE_URL}/libs-release/javax/jms/jms-api/1.1-rev-1/jms-api-1.1-rev-1.jar -o jms-api.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/jaxen/jaxen/1.1.6/jaxen-1.1.6.jar -o jaxen.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.6/jmstool-0.0.6.jar -o jmstool.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.7/jmstool-0.0.7.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/batch-manager/1.0.1/batch-manager-1.0.1.jar -o ../batchmanager/batch-manager.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/bulk-image-load/1.0.2/bulk-image-load-1.0.2.jar -o ../bulk-image-load/bulk-image-load.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/compliance-trigger/1.1.2/compliance-trigger-1.1.2.jar -o ../compliance-trigger/compliance-trigger.jar && \

--- a/weblogic-batch/admin/jms/README.md
+++ b/weblogic-batch/admin/jms/README.md
@@ -1,4 +1,5 @@
 
+
 This is the location for various JMS administration scripts that are typically run manually by CSI or are scheduled to run on the cron.
 
 ### list-all-jms.sh
@@ -45,6 +46,33 @@ The script makes use of list-all-jms.sh and processes the output from that to ge
 held in the environment variable `EMAIL_ADDRESS_CSI`.
 
 
+### list-all-jms-ef-responses.sh
+
+This is run in order to list all "stuck" EF response JMS messages in the EfilingErrorQueue across all WebLogic servers.
+
+No parameters are required.
+
+For example:
+./list-all-jms-ef-responses.sh
+
+The script makes use of list-all-jms.sh and processes the output from that to list all EF response messages, along with an
+indication of whether they are safe to delete or need further investigation.
+
+It will display messages on each JMS server and show:
+
+- the object id (which is useful in the Weblogic console)
+- if the response is ACCEPTED or REJECTED,
+- the barcode
+- either INVESTIGATE or OK_TO_DELETE. 
+
+E.g:
+```2023-07-06T15:41:51,709 [list-all-jms-ef-responses.sh] INFO  851960.1688648406753.0 REJECTED	 XBZ74XOB INVESTIGATE```
+
+If the barcode is not found on the EWF admin website or there is already a response 
+with a status that differs from the status (ACCEPTED or REJECTED) inside the JMS message, then INVESTIGATE will be shown, and it is not safe to delete the message.
+If the barcode is found and the response on the admin website is the same, then OK_TO_DELETE will be shown, and the message can usually be deleted without any issues.
+
+
 ### reprocess-jms.sh
 
 This is run when there is a need to move JMS messages from one queue to another across a range of WebLogic servers.
@@ -70,12 +98,13 @@ For example, if the following environment variables were defined, the script wou
 
 This is run when there is a need to resend an accept respone to the EWF or XML service.  The script injects a new JMS response message into the EfilingQueue queue, based on a supplied xml file containing the data from the CHIPS TRANSACTION_DOC_XML table.
 
-The following parameter is required:
+The following parameters are required:
 
 - The path of the xml file 
+- The status of the response to send, such as "accept" or "reject"
 
 For example:
-./resend-response-jms.sh ./a.xml
+./resend-response-jms.sh ./a.xml reject
 
 The script injects the JMS message into the JMS server that is set in the environment variable `JMS_SERVER_URL_1`
 

--- a/weblogic-batch/admin/jms/inject-jms.sh
+++ b/weblogic-batch/admin/jms/inject-jms.sh
@@ -8,6 +8,7 @@
 #  The expected parameters for chaps.jms.InjectResponseJMSMessages are, in order:
 #
 #  PATH TO XML FILE - the file to create the JMS message from
+#  STATUS - accept or reject
 #  JMS SERVER NAME@$DESTINATION QUEUE - the queue to inject the message into, e.g. JMSServer1@uk.gov.ch.chips.jms.EfilingQueue
 #  JMS SERVER URL - the t3 or t3s URL for the WebLogic server, e.g. t3s://1.2.3.4:1234
 #  USERNAME - e.g. weblogic

--- a/weblogic-batch/admin/jms/list-all-jms-ef-responses.sh
+++ b/weblogic-batch/admin/jms/list-all-jms-ef-responses.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# =============================================================================
+#
+#  This script is used to list stuck EFiling JMS messages in the EfilingErrorQueue   
+#  on all JMS servers.
+#
+#  It will display messages on each JMS server and show the object id 
+#  (which is useful in the Weblogic console), if the response is ACCEPTED or REJECTED,
+#  the barcode and either INVESTIGATE or OK_TO_DELETE. E.g:
+#  2023-07-06T15:41:51,709 [list-all-jms-ef-responses.sh] INFO  851960.1688648406753.0 REJECTED	 XBZ74XOB INVESTIGATE
+#
+#  If the barcode is not found on the ewf admin website or there is already a response 
+#  that differs from the JMS message then INVESTIGATE will be shown and it is not safe to delete the message.
+#  If the barcode is found and the response on the admin website is the same, then OK_TO_DELETE will be shown.
+# 
+#  No parameters are required, but there are a number of environment variables that need to be present:
+#
+#  One or more environment variables that list the connection details for the JMS Servers on which to 
+#  perform the list operation. These variables must be called JMS_SERVER_URL_#
+#  (where # is a unique identifier such as a number).  E.g.
+#
+#  JMS_SERVER_URL_1=t3s://chips-ef-batch0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_2=t3s://chips-ef-batch1.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_3=t3s://chips-users-rest0.heritage.aws.internal:21031|JMSServer1
+#  JMS_SERVER_URL_4=t3s://chips-users-rest1.heritage.aws.internal:21031|JMSServer1
+#
+#  WEBLOGIC_ADMIN_USERNAME - Weblogic admin user
+#  ADMIN_PASSWORD - Weblogic admin password
+#  EWF_ADMIN_PROXY_HOST - proxy server host to allow https access to ewf admin website
+#  EWF_ADMIN_PROXY_PORT - proxy server port
+#  EWF_ADMIN_HOST - FQDN of the ewf admin website
+#  EWF_ADMIN_USER - username to login with
+#  EWF_ADMIN_PASSWORD - password to login with
+# =============================================================================
+
+cd /apps/oracle/admin/jms
+
+# load variables created from setCron script
+source /apps/oracle/env.variables
+
+# set up logging
+LOGS_DIR=../../logs/jms
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-list-all-jms-ef-responses-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/oracle/scripts/logging_functions
+
+exec > >(tee "${LOG_FILE}") 2>&1
+
+QUEUE=uk.gov.ch.chips.jms.EfilingErrorQueue
+
+# Obtain Admin Site session id
+SESSION_ID=$(curl -s --proxy ${EWF_ADMIN_PROXY_HOST}:${EWF_ADMIN_PROXY_PORT} -X POST -d "user=${EWF_ADMIN_USER}&password=${EWF_ADMIN_PASSWORD}" "https://${EWF_ADMIN_HOST}/login" | grep welcome | sed 's/.*\/\([a-z0-9]*\)\/.*/\1/g')
+f_logInfo "Using session_id=${SESSION_ID}"
+
+JMS_SERVERS=$(env | sort -k1.18 | grep "^JMS_SERVER_URL_")
+for JMS_SERVER in ${JMS_SERVERS};
+do
+  while IFS='|' read -r JMS_SERVER_URL JMS_SERVER_NAME;
+  do
+    f_logInfo "Processing ${JMS_SERVER} listing messages in ${QUEUE}"
+
+    ./list-jms.sh ${JMS_SERVER_NAME}@${QUEUE} ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD} | grep -E "barcode>|ObjectMessage" | uniq | sed 's/.*<\(.*\)>,.*\([A-Z][A-Z][A-Z][A-Z][A-Z]TED\).*/\1 \2/g' | sed 's/<barcode>\(.*\)<\/barcode>/\1/g' | paste - - | tr -d '' > list-all-jms-ef-responses.out
+    while IFS=" " read OBJECT_ID STATUS BARCODE
+    do
+    # Check if status matches FE
+      curl -s --proxy ${EWF_ADMIN_PROXY_HOST}:${EWF_ADMIN_PROXY_PORT} -X POST -d "barcode=${BARCODE}&search=Search&company=&search=1" "https://${EWF_ADMIN_HOST}/${SESSION_ID}/ewfbarcompanysearch" | grep -i -q ${STATUS}
+      RESULTCODE=$?
+
+      if [[ RESULTCODE -eq 0 ]]; then
+        RESULT="OK_TO_DELETE"
+      else
+        RESULT="INVESTIGATE"
+      fi
+
+      f_logInfo "${OBJECT_ID} ${STATUS} ${BARCODE} ${RESULT}"
+
+    done < list-all-jms-ef-responses.out
+
+  done < <(echo ${JMS_SERVER##*=})
+done

--- a/weblogic-batch/admin/jms/resend-response-jms.sh
+++ b/weblogic-batch/admin/jms/resend-response-jms.sh
@@ -6,11 +6,12 @@
 #  creating a new JMS message from an xml document that has been manually taken 
 #  from the TRANSACTION_DOC_XML table on the CHIPS OLTP database. 
 #
-#  This script expects one parameter:
+#  This script expects two parameters:
 #
 #  XML_PATH - the path to the xml file
+#  STATUS - accept or reject
 #
-#  In addition to that parameter, it also expects an environment variable
+#  In addition to those, it also expects an environment variable
 #  that holds the connection details for a JMS Server on which to
 #  create the message. The variable must be called JMS_SERVER_URL_1
 #
@@ -33,17 +34,18 @@ source /apps/oracle/scripts/logging_functions
 
 exec > >(tee "${LOG_FILE}") 2>&1
 
-if [ "$#" -ne 1 ]
+if [ "$#" -ne 2 ]
 then
-  f_logError "Invalid number of arguments - expected 1"
-  f_logInfo "Usage: ./resend-response-jms.sh <path to xml file>"
-  f_logInfo "Example: ./resend-response-jms.sh a.xml"
+  f_logError "Invalid number of arguments - expected 2"
+  f_logInfo "Usage: ./resend-response-jms.sh <path to xml file> <status>"
+  f_logInfo "Example: ./resend-response-jms.sh a.xml reject"
   exit 1
 fi
 
 XML_FILE=$1
+STATUS=$2
 JMS_SERVER_URL=${JMS_SERVER_URL_1%%|*}
 JMS_SERVER_NAME=${JMS_SERVER_URL_1##*|}
 
-f_logInfo "Processing ${JMS_SERVER} injecting JMS message from ${XML_FILE}"
-./inject-jms.sh ${XML_FILE} ${JMS_SERVER_NAME}@uk.gov.ch.chips.jms.EfilingQueue ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD}
+f_logInfo "Processing ${JMS_SERVER} injecting JMS message from ${XML_FILE} with a status of ${STATUS}"
+./inject-jms.sh ${XML_FILE} ${STATUS} ${JMS_SERVER_NAME}@uk.gov.ch.chips.jms.EfilingQueue ${JMS_SERVER_URL} ${WEBLOGIC_ADMIN_USERNAME} ${ADMIN_PASSWORD}


### PR DESCRIPTION
Added a script, `list-all-jms-ef-responses.sh`, that lists messages and indicates if they are safe to delete or require investigation.

The following env vars are needed in chips.properties:
`EWF_ADMIN_PROXY_HOST` - proxy server host to allow https access to ewf admin website
`EWF_ADMIN_PROXY_PORT` - proxy server port
`EWF_ADMIN_HOST` - FQDN of the ewf admin website
`EWF_ADMIN_USER` - username to login with
`EWF_ADMIN_PASSWORD` - password to login with

Also updated jmstool library to 0.0.7 to allow EF response messages to be injected with a status (reject or accept).  Previously, it was hardcoded to accept, so rejections couldn't be sent properly.  The associated shell scripts and README have been updated to cater for the extra parameter.