### PR TITLE
Update default version of log4j libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ COPY --chown=weblogic weblogic-batch ${ORACLE_HOME}/
 RUN mkdir -p ${ORACLE_HOME}/libs && \
     mkdir -p ${ORACLE_HOME}/.ssh && \
     cd ${ORACLE_HOME}/libs && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-api/2.21.1/log4j-api-2.21.1.jar -o log4j-api.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-core/2.21.1/log4j-core-2.21.1.jar -o log4j-core.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-1.2-api/2.21.1/log4j-1.2-api-2.21.1.jar -o log4j-1.2-api.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.jar -o log4j-api.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.jar -o log4j-core.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-1.2-api/2.25.3/log4j-1.2-api-2.25.3.jar -o log4j-1.2-api.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-jcl/2.25.3/log4j-jcl-2.25.3.jar -o log4j-jcl.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring/2.0.7/spring-2.0.7.jar -o spring.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar -o commons-logging.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/thoughtworks/xstream/xstream/1.4.3/xstream-1.4.3.jar -o xstream.jar && \
@@ -70,9 +71,6 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-aop/4.3.30.RELEASE/spring-aop-4.3.30.RELEASE.jar -o spring-aop-4.3.30.RELEASE.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-expression/4.3.30.RELEASE/spring-expression-4.3.30.RELEASE.jar -o spring-expression-4.3.30.RELEASE.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/javax/jms/javax.jms-api/2.0.1/javax.jms-api-2.0.1.jar -o javax.jms-api-2.0.1.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-api/2.25.3/log4j-api-2.25.3.jar -o log4j-api-2.25.3.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-core/2.25.3/log4j-core-2.25.3.jar -o log4j-core-2.25.3.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-jcl/2.25.3/log4j-jcl-2.25.3.jar -o log4j-jcl-2.25.3.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-tx/4.3.30.RELEASE/spring-tx-4.3.30.RELEASE.jar -o spring-tx-4.3.30.RELEASE.jar && \
     chmod -R 750 ${ORACLE_HOME}/*
 

--- a/weblogic-batch/batchmanager/batchmanager.sh
+++ b/weblogic-batch/batchmanager/batchmanager.sh
@@ -9,7 +9,7 @@ source /apps/oracle/env.variables
 envsubst < batchmanager.properties.template > chips_batchmanager.properties
 
 # Updated CLASSPATH - batch-manager.jar and other dependencies
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/spring-core-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-tx-4.3.30.RELEASE.jar:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/spring-beans-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-context-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-jms-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-aop-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-expression-4.3.30.RELEASE.jar:/apps/oracle/libs/javax.jms-api-2.0.1.jar:/apps/oracle/libs/log4j-api-2.25.3.jar:/apps/oracle/libs/log4j-core-2.25.3.jar:/apps/oracle/libs/log4j-jcl-2.25.3.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/batchmanager/batch-manager.jar
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/spring-core-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-tx-4.3.30.RELEASE.jar:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/spring-beans-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-context-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-jms-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-aop-4.3.30.RELEASE.jar:/apps/oracle/libs/spring-expression-4.3.30.RELEASE.jar:/apps/oracle/libs/javax.jms-api-2.0.1.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-jcl.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/batchmanager/batch-manager.jar
 
 # set up logging
 LOGS_DIR=../logs/batchmanager

--- a/weblogic-batch/bulk-image-load/bulk-image-load.sh
+++ b/weblogic-batch/bulk-image-load/bulk-image-load.sh
@@ -10,7 +10,7 @@ HOME=${KEEP_HOME}
 # create properties file and substitutes values
 envsubst < bulk-image-load.properties.template > bulk-image-load.properties
 
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/libs/log4j-api-2.25.3.jar:/apps/oracle/libs/log4j-core-2.25.3.jar:/apps/oracle/libs/log4j-jcl-2.25.3.jar:/apps/oracle/libs/javax.jms-api-2.0.1.jar:/apps/oracle/bulk-image-load/bulk-image-load.jar
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-jcl.jar:/apps/oracle/libs/javax.jms-api-2.0.1.jar:/apps/oracle/bulk-image-load/bulk-image-load.jar
 
 # Set up mail config for msmtp & load alerting functions
 envsubst < ../.msmtprc.template > ../.msmtprc


### PR DESCRIPTION
Updating to later versions to address vulnerability Removing duplicate versioned jars and updating scripts to use defaults

For consistency with version used in [ASM-1472]

[ASM-1472]: https://companieshouse.atlassian.net/browse/ASM-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ