### PR TITLE
Bump officer-bulk-process & add updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ running-servers/
 # Eclipse files
 .project
 .settings
+.idea
 
 # Block variants of docker-compose file throughout project
 docker-compose*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,13 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/apache/logging/log4j/log4j-jcl/2.25.3/log4j-jcl-2.25.3.jar -o log4j-jcl.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring/2.0.7/spring-2.0.7.jar -o spring.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar -o commons-logging.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/thoughtworks/xstream/xstream/1.4.3/xstream-1.4.3.jar -o xstream.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar -o xstream.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/commons-lang/commons-lang/2.5/commons-lang-2.5.jar -o commons-lang.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/cglib/cglib-nodep/2.1_3/cglib-nodep-2.1_3.jar -o cglib-nodep.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/joda-time/joda-time/2.9.1/joda-time-2.9.1.jar -o joda-time.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/oracle/database/jdbc/ojdbc11/23.9.0.25.07/ojdbc11-23.9.0.25.07.jar -o ojdbc11.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/oracle/weblogic/wlthint3client/14.1.2.0/wlthint3client-14.1.2.0.jar -o wlthint3client.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/oracle/weblogic/wlthint3client.jakarta/14.1.2.0/wlthint3client.jakarta-14.1.2.0.jar -o wlthint3client.jakarta.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/bea/core/management/jmx/14.1.2.0/jmx-14.1.2.0.jar -o com.bea.core.management.jmx.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/bea/core/datasource6/14.1.2.0/datasource6-14.1.2.0.jar -o com.bea.core.datasource6.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/com/bea/core/resourcepool/14.1.2.0/resourcepool-14.1.2.0.jar -o com.bea.core.resourcepool.jar && \
@@ -59,7 +60,7 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/doc1-producer/2.0.4/doc1-producer-2.0.4.jar -o ../doc1-producer/doc1-producer.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/image-regeneration/1.2.6/image-regeneration-1.2.6.jar -o ../image-regeneration/image-regeneration.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/letter-producer/2.0.1/letter-producer-2.0.1.jar -o ../letter-producer/letter-producer.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/officer-bulk-process/1.0.8/officer-bulk-process-1.0.8.jar -o ../officer-bulk-process/officer-bulk-process.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/officer-bulk-process/2.0.1/officer-bulk-process-2.0.1.jar -o ../officer-bulk-process/officer-bulk-process.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/psc-pursuit-trigger/2.1.2/psc-pursuit-trigger-2.1.2.jar -o ../psc-pursuit-trigger/psc-pursuit-trigger.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/image-api-message-generator/1.0/image-api-message-generator-1.0.jar -o ../mid-to-chs/image-api-message-generator.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/image-sender/0.1.32/image-sender-0.1.32.jar -o image-sender.jar && \
@@ -70,8 +71,16 @@ RUN mkdir -p ${ORACLE_HOME}/libs && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-jms/4.3.30.RELEASE/spring-jms-4.3.30.RELEASE.jar -o spring-jms-4.3.30.RELEASE.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-aop/4.3.30.RELEASE/spring-aop-4.3.30.RELEASE.jar -o spring-aop-4.3.30.RELEASE.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-expression/4.3.30.RELEASE/spring-expression-4.3.30.RELEASE.jar -o spring-expression-4.3.30.RELEASE.jar && \
-    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/javax/jms/javax.jms-api/2.0.1/javax.jms-api-2.0.1.jar -o javax.jms-api-2.0.1.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-tx/4.3.30.RELEASE/spring-tx-4.3.30.RELEASE.jar -o spring-tx-4.3.30.RELEASE.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-core/7.0.6/spring-core-7.0.6.jar -o spring-core-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-jms/7.0.6/spring-jms-7.0.6.jar -o spring-jms-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-jdbc/7.0.6/spring-jdbc-7.0.6.jar -o spring-jdbc-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-context/7.0.6/spring-context-7.0.6.jar -o spring-context-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-beans/7.0.6/spring-beans-7.0.6.jar -o spring-beans-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-aop/7.0.6/spring-aop-7.0.6.jar -o spring-aop-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/org/springframework/spring-tx/7.0.6/spring-tx-7.0.6.jar -o spring-tx-7.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/io/micrometer/micrometer-observation/1.16.4/micrometer-observation-1.16.4.jar -o micrometer-observation.jar && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/javax/jms/javax.jms-api/2.0.1/javax.jms-api-2.0.1.jar -o javax.jms-api-2.0.1.jar && \
     chmod -R 750 ${ORACLE_HOME}/*
 
 FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.3

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process-single.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process-single.sh
@@ -49,8 +49,7 @@ HOME=${KEEP_HOME}
 # create properties file and substitutes values
 envsubst <officer-poller.properties.template >officer-poller.properties
 
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/xstream.jar:/apps/oracle/libs/cglib-nodep.jar:/apps/oracle/libs/joda-time.jar:/apps/oracle/libs/commons-lang.jar:/apps/oracle/libs/ojdbc11.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/libs/spring.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-1.2-api.jar:/apps/oracle/libs/com.bea.core.datasource6.jar:/apps/oracle/libs/com.bea.core.resourcepool.jar:/apps/oracle/libs/com.oracle.weblogic.jdbc.jar:/apps/oracle/officer-bulk-process/officer-bulk-process.jar
-JAVA_ARGS="--add-opens=java.desktop/java.awt.font=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED"
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/xstream.jar:/apps/oracle/libs/cglib-nodep.jar:/apps/oracle/libs/joda-time.jar:/apps/oracle/libs/ojdbc11.jar:/apps/oracle/libs/wlthint3client.jakarta.jar:/apps/oracle/libs/spring-core-7.jar:/apps/oracle/libs/spring-jms-7.jar:/apps/oracle/libs/spring-jdbc-7.jar:/apps/oracle/libs/spring-context-7.jar:/apps/oracle/libs/spring-beans-7.jar:/apps/oracle/libs/spring-tx-7.jar:/apps/oracle/libs/spring-aop-7.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-1.2-api.jar:/apps/oracle/libs/com.bea.core.datasource6.jar:/apps/oracle/libs/com.bea.core.resourcepool.jar:/apps/oracle/libs/com.oracle.weblogic.jdbc.jar:/apps/oracle/libs/micrometer-observation.jar:/apps/oracle/officer-bulk-process/officer-bulk-process.jar
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
+++ b/weblogic-batch/officer-bulk-process/officer-bulk-process.sh
@@ -38,8 +38,7 @@ HOME=${KEEP_HOME}
 # create properties file and substitutes values
 envsubst <officer-poller.properties.template >officer-poller.properties
 
-CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/xstream.jar:/apps/oracle/libs/cglib-nodep.jar:/apps/oracle/libs/joda-time.jar:/apps/oracle/libs/commons-lang.jar:/apps/oracle/libs/ojdbc11.jar:/apps/oracle/libs/wlthint3client.jar:/apps/oracle/libs/spring.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-1.2-api.jar:/apps/oracle/libs/com.bea.core.datasource6.jar:/apps/oracle/libs/com.bea.core.resourcepool.jar:/apps/oracle/libs/com.oracle.weblogic.jdbc.jar:/apps/oracle/officer-bulk-process/officer-bulk-process.jar
-JAVA_ARGS="--add-opens=java.desktop/java.awt.font=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED"
+CLASSPATH=$CLASSPATH:.:/apps/oracle/libs/commons-logging.jar:/apps/oracle/libs/xstream.jar:/apps/oracle/libs/cglib-nodep.jar:/apps/oracle/libs/joda-time.jar:/apps/oracle/libs/ojdbc11.jar:/apps/oracle/libs/wlthint3client.jakarta.jar:/apps/oracle/libs/spring-core-7.jar:/apps/oracle/libs/spring-jms-7.jar:/apps/oracle/libs/spring-jdbc-7.jar:/apps/oracle/libs/spring-context-7.jar:/apps/oracle/libs/spring-beans-7.jar:/apps/oracle/libs/spring-tx-7.jar:/apps/oracle/libs/spring-aop-7.jar:/apps/oracle/libs/log4j-core.jar:/apps/oracle/libs/log4j-api.jar:/apps/oracle/libs/log4j-1.2-api.jar:/apps/oracle/libs/com.bea.core.datasource6.jar:/apps/oracle/libs/com.bea.core.resourcepool.jar:/apps/oracle/libs/com.oracle.weblogic.jdbc.jar:/apps/oracle/libs/micrometer-observation.jar:/apps/oracle/officer-bulk-process/officer-bulk-process.jar
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc


### PR DESCRIPTION
Bumped officer-bulk-process to v2.0.1 & updated dependencies:
- updated xstream version to 1.4.21 (only used by officer-bulk-process)
- added wlthint3client.jakarta variant of wl lib
- added various v7.x.x spring jars - downloaded with -7 versioning to allow selective use on classpaths while keeping it simple to update minor versions for dependency updates etc without requiring classpath edit
- added additional runtime dependency micrometer-observation
- updated officer-bulk-process script classpaths to use updated jars, and removed no-longer-required JAVA_ARGS (as updated jars are module-aware)
(Also added IntelliJ .idea files to .gitignore)